### PR TITLE
fix `Float32`/`Float64` issue for 3D `surface_flux_kernel1!`

### DIFF
--- a/test/compressible_euler_3d.jl
+++ b/test/compressible_euler_3d.jl
@@ -1,5 +1,5 @@
 # The header part of test
-equations = CompressibleEulerEquations3D(1.4)
+equations = CompressibleEulerEquations3D(1.4f0)
 
 initial_condition = initial_condition_convergence_test
 

--- a/trixi/src/equations/compressible_euler_3d.jl
+++ b/trixi/src/equations/compressible_euler_3d.jl
@@ -376,7 +376,7 @@ end
   v1 = rho_v1 / rho
   v2 = rho_v2 / rho
   v3 = rho_v3 / rho
-  p = (equations.gamma - 1) * (rho_e - 0.5 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3))
+  p = (equations.gamma - 1) * (rho_e - 0.5f0 * (rho_v1 * v1 + rho_v2 * v2 + rho_v3 * v3))
   if orientation == 1
     f1 = rho_v1
     f2 = rho_v1 * v1 + p

--- a/trixi/src/equations/numerical_fluxes.jl
+++ b/trixi/src/equations/numerical_fluxes.jl
@@ -21,7 +21,7 @@ DG method (except floating point errors).
   f_rr = flux(u_rr, orientation_or_normal_direction, equations)
 
   # Average regular fluxes
-  return 0.5 * (f_ll + f_rr)
+  return 0.5f0 * (f_ll + f_rr)
 end
 
 
@@ -145,7 +145,7 @@ DissipationLocalLaxFriedrichs() = DissipationLocalLaxFriedrichs(max_abs_speed_na
 
 @inline function (dissipation::DissipationLocalLaxFriedrichs)(u_ll, u_rr, orientation_or_normal_direction, equations)
   λ = dissipation.max_abs_speed(u_ll, u_rr, orientation_or_normal_direction, equations)
-  return -0.5 * λ * (u_rr - u_ll)
+  return -0.5f0 * λ * (u_rr - u_ll)
 end
 
 Base.show(io::IO, d::DissipationLocalLaxFriedrichs) = print(io, "DissipationLocalLaxFriedrichs(", d.max_abs_speed, ")")


### PR DESCRIPTION
The issue #3 comes from automatic promotion of `Float32` to `Float64` used explicitly in constants such as `0.5` in the code. One way to fix it is to change all constants to `Float64` - which should be promoted automatically to `Float64` if required.