### PR TITLE
copy `du` back to CPU in 2D `rhs_gpu!`

### DIFF
--- a/cuda_dg_2d.jl
+++ b/cuda_dg_2d.jl
@@ -804,11 +804,11 @@ end
 
 # Pack kernels into `rhs_gpu!()`
 #################################################################################
-function rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations,
+function rhs_gpu!(du_cpu, u_cpu, t, mesh::TreeMesh{2}, equations,
     initial_condition, boundary_conditions, source_terms::Source,
     dg::DGSEM, cache) where {Source}
 
-    du, u = copy_to_gpu!(du, u)
+    du, u = copy_to_gpu!(du_cpu, u_cpu)
 
     cuda_volume_integral!(
         du, u, mesh,
@@ -834,7 +834,8 @@ function rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations,
     cuda_sources!(du, u, t,
         source_terms, equations, cache)
 
-    du, u = copy_to_cpu!(du, u)
+    du_computed, _ = copy_to_cpu!(du, u)
+    du_cpu .= du_computed
 
     return nothing
 end


### PR DESCRIPTION
This is related to #7. In Julia, `du, u = copy_to_cpu!(du, u)` just assigns something new to the names `du`  and `u`. What you want to achieve here is to overwrite the content of the array passed as first argument to `rhs_gpu!` with the RHS you computed on GPUs. This should fix the problem of not updating `du`.

After this change, I get
```julia
julia> include("cuda_dg_2d.jl")
semidiscretize_gpu (generic function with 1 method)

julia> include("examples/example2.jl")
(-2.5131248918341953e-5, 1.1323768497106812e-5)
```

Before, I got
```julia
julia> include("cuda_dg_2d.jl")
semidiscretize_gpu (generic function with 1 method)

julia> include("examples/example2.jl")
(-0.15904403780456278, 0.27709502086661075)
```

However, there is still some difference between the GPU and CPU versions:
```julia
julia> du_cpu =zero(ode_cpu.u0);

julia> rhs!(du_cpu, ode_cpu.u0, ode_cpu.p, 0.0)

julia> du_gpu = zero(ode_gpu.u0);

julia> rhs_gpu!(du_gpu, ode_gpu.u0, ode_gpu.p, 0.0f0)

julia> extrema(du_cpu - du_gpu)
(-0.0003617229645898057, 0.0003059853949707761)

julia> extrema(du_cpu - du_gpu) ./ maximum(abs, du_cpu)
(-8.768471211163349e-5, 7.417345287657502e-5)
```
This is roughly two order of magnitude bigger than `eps(Float32)`. Thus, I think there may be some additional issues. It would be great if you could debug the implementations step by step to check where these differences come from. Please let me know if you need hep with that.
