### PR TITLE
Enable CI tests on x86 architecture 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,7 @@ jobs:
           - windows-latest
         arch:
           - x64
-          # Failed to precompile Trixi Julia 1.10 - windows-latest - x86
-          # No binaries for Julia 1.10 - macOS-latest - x86
-          # - x86
+          - x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
The previous tests only run on x64 due to some upstream issue and lack of Julia binary supports - now it is okay to enable tests on x86 architecture.

Update:
- Trixi.jl now supports precompile for Julia 1.10 on x86 for Ubuntu and Windows.
- Julia binary support for macOS on x86 is still unavailable.