### PR TITLE
Set version bounds for Trixi.jl to ensure compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,15 +9,13 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Trixi = "a7f1ee26-1774-49b1-8366-f1abc58fbfcb"
-TrixiBase = "9a0f1c46-06d5-4909-a5a3-ce25d3fa3284"
 
 [compat]
 BenchmarkTools = "1"
 CUDA = "5"
 SciMLBase = "2"
 StaticArrays = "1"
-Trixi = "0.8, 0.9"
-TrixiBase = "0.1"
+Trixi = "0.8, 0.9.8 - 0.9.8"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 TrixiCUDA.jl offers CUDA acceleration for solving hyperbolic PDEs.
 
+⚠️ **_Warning_**: Our package may not always be updated with the latest updates or improvements in Trixi.jl. Forcing an update of Trixi.jl as a dependency beyond the version bounds specified in `Project.toml` could result in unexpected errors.
+
 *Update on Nov 21, 2024*: 
 - Due to the [issue](https://github.com/trixi-framework/Trixi.jl/issues/2108) from upstream with Trixi.jl and CUDA.jl in Julia v1.11, this package now supports only Julia v1.10. Using or developing this package with Julia v1.11 will result in precompilation errors. To fix this, downgrade to Julia v1.10. If you have any other problems, please file issues [here](https://github.com/trixi-gpu/TrixiCUDA.jl/issues).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 TrixiCUDA.jl offers CUDA acceleration for solving hyperbolic PDEs.
 
-⚠️ **_Warning_**: Our package may not always be updated with the latest updates or improvements in Trixi.jl. Forcing an update of Trixi.jl as a dependency beyond the version bounds specified in `Project.toml` could result in unexpected errors.
+⚠️ **_Warning_**: Our package may not always be updated with the latest updates or improvements in Trixi.jl. Forcing an update of Trixi.jl as a dependency for TrixiCUDA.jl beyond the version bounds specified in `Project.toml` may cause unexpected errors.
 
 *Update on Nov 21, 2024*: 
 - Due to the [issue](https://github.com/trixi-framework/Trixi.jl/issues/2108) from upstream with Trixi.jl and CUDA.jl in Julia v1.11, this package now supports only Julia v1.10. Using or developing this package with Julia v1.11 will result in precompilation errors. To fix this, downgrade to Julia v1.10. If you have any other problems, please file issues [here](https://github.com/trixi-gpu/TrixiCUDA.jl/issues).

--- a/src/TrixiCUDA.jl
+++ b/src/TrixiCUDA.jl
@@ -33,14 +33,14 @@ using SciMLBase: ODEProblem, FullSpecialize
 
 using StaticArrays: SVector
 
+# Change to use the Base.log and Base.sqrt - need to be fixed to avoid outputs
+set_log_type!("log_Base")
+set_sqrt_type!("sqrt_Base")
+
 # Include other source files
 include("auxiliary/auxiliary.jl")
 include("semidiscretization/semidiscretization.jl")
 include("solvers/solvers.jl")
-
-# Change to use the Base.log and Base.sqrt - need to be fixed to avoid outputs
-set_log_type!("log_Base")
-set_sqrt_type!("sqrt_Base")
 
 # Export the public APIs
 export SemidiscretizationHyperbolicGPU


### PR DESCRIPTION
Trixi.jl updates every one or two weeks. Without version bounds (especially the upper bound), the package manager will always try to update it to the latest version. However, minor algorithm fixes and improvements in new versions can break our accuracy tests if we don’t keep up.

The current WAR is to set version bounds for Trixi.jl in project.toml and we will check the new updates at least once a month to  extend this upper bound. Also, the README.md file is modified based on this change.