### PR TITLE
Fuse `reset_du!` function into volume integral kernels

### DIFF
--- a/benchmark/benchmark_1d.jl
+++ b/benchmark/benchmark_1d.jl
@@ -60,20 +60,23 @@ u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
 # Reset du
-@info "Time for reset_du! on GPU"
-CUDA.@time TrixiCUDA.reset_du!(du_gpu)
-@info "Time for reset_du! on CPU"
-@time Trixi.reset_du!(du, solver, cache)
+# @info "Time for reset_du! on GPU"
+# CUDA.@time TrixiCUDA.reset_du!(du_gpu)
+# @info "Time for reset_du! on CPU"
+# @time Trixi.reset_du!(du, solver, cache)
 
-# Volume integral
-@info "Time for volume_integral! on GPU"
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
 CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                            Trixi.have_nonconservative_terms(equations_gpu),
                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
                                            cache_gpu)
-@info "Time for volume_integral! on CPU"
-@time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                  equations, solver.volume_integral, solver, cache)
+@info "Time for reset_du! and volume_integral! on CPU"
+@time begin
+    Trixi.reset_du!(du, solver, cache)
+    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+                                equations, solver.volume_integral, solver, cache)
+end
 
 # Prolong to interfaces
 @info "Time for prolong2interfaces! on GPU"

--- a/benchmark/benchmark_1d.jl
+++ b/benchmark/benchmark_1d.jl
@@ -59,7 +59,7 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-# Reset du
+# # Reset du
 # @info "Time for reset_du! on GPU"
 # CUDA.@time TrixiCUDA.reset_du!(du_gpu)
 # @info "Time for reset_du! on CPU"

--- a/benchmark/benchmark_2d.jl
+++ b/benchmark/benchmark_2d.jl
@@ -59,107 +59,101 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-@info "Time for reset_du! and volume_integral! on GPU"
-@benchmark begin
-    CUDA.@sync TrixiCUDA.reset_du!(du_gpu)
-    CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                               Trixi.have_nonconservative_terms(equations_gpu),
-                                               equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                               cache_gpu)
-end
-
 # # Reset du
 # @info "Time for reset_du! on GPU"
 # CUDA.@time TrixiCUDA.reset_du!(du_gpu)
 # @info "Time for reset_du! on CPU"
 # @time Trixi.reset_du!(du, solver, cache)
 
-# # Volume integral
-# @info "Time for volume_integral! on GPU"
-# CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-#                                            Trixi.have_nonconservative_terms(equations_gpu),
-#                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
-#                                            cache_gpu)
-# @info "Time for volume_integral! on CPU"
-# @time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-#                                   equations, solver.volume_integral, solver, cache)
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
+CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                           Trixi.have_nonconservative_terms(equations_gpu),
+                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                           cache_gpu)
+@info "Time for reset_du! and volume_integral! on CPU"
+@time begin
+    Trixi.reset_du!(du, solver, cache)
+    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+                                equations, solver.volume_integral, solver, cache)
+end
 
-# # Prolong to interfaces
-# @info "Time for prolong2interfaces! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-# @info "Time for prolong2interfaces! on CPU"
-# @time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
+# Prolong to interfaces
+@info "Time for prolong2interfaces! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
+@info "Time for prolong2interfaces! on CPU"
+@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# # Interface flux
-# @info "Time for interface_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-#                                           Trixi.have_nonconservative_terms(equations_gpu),
-#                                           equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for interface_flux! on CPU"
-# @time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-#                                  Trixi.have_nonconservative_terms(equations), equations,
-#                                  solver.surface_integral, solver, cache)
+# Interface flux
+@info "Time for interface_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
+                                          Trixi.have_nonconservative_terms(equations_gpu),
+                                          equations_gpu, solver_gpu, cache_gpu)
+@info "Time for interface_flux! on CPU"
+@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
+                                 Trixi.have_nonconservative_terms(equations), equations,
+                                 solver.surface_integral, solver, cache)
 
-# # Prolong to boundaries
-# @info "Time for prolong2boundaries! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-#                                               equations_gpu, cache_gpu)
-# @info "Time for prolong2boundaries! on CPU"
-# @time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
+# Prolong to boundaries
+@info "Time for prolong2boundaries! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
+                                              equations_gpu, cache_gpu)
+@info "Time for prolong2boundaries! on CPU"
+@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# # Boundary flux
-# @info "Time for boundary_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-#                                          Trixi.have_nonconservative_terms(equations_gpu),
-#                                          equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for boundary_flux! on CPU"
-# @time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-#                                 solver.surface_integral, solver)
+# Boundary flux
+@info "Time for boundary_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
+                                         Trixi.have_nonconservative_terms(equations_gpu),
+                                         equations_gpu, solver_gpu, cache_gpu)
+@info "Time for boundary_flux! on CPU"
+@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
+                                solver.surface_integral, solver)
 
-# # Prolong to mortars
-# @info "Time for prolong2mortars! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-#                                            TrixiCUDA.check_cache_mortars(cache_gpu),
-#                                            solver_gpu, cache_gpu)
-# @info "Time for prolong2mortars! on CPU"
-# @time Trixi.prolong2mortars!(cache, u, mesh, equations,
-#                              solver.mortar, solver.surface_integral, solver)
+# Prolong to mortars
+@info "Time for prolong2mortars! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
+                                           TrixiCUDA.check_cache_mortars(cache_gpu),
+                                           solver_gpu, cache_gpu)
+@info "Time for prolong2mortars! on CPU"
+@time Trixi.prolong2mortars!(cache, u, mesh, equations,
+                             solver.mortar, solver.surface_integral, solver)
 
-# # Mortar flux
-# @info "Time for mortar_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-#                                        Trixi.have_nonconservative_terms(equations_gpu),
-#                                        equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for mortar_flux! on CPU"
-# @time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-#                               Trixi.have_nonconservative_terms(equations), equations,
-#                               solver.mortar, solver.surface_integral, solver, cache)
+# Mortar flux
+@info "Time for mortar_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
+                                       Trixi.have_nonconservative_terms(equations_gpu),
+                                       equations_gpu, solver_gpu, cache_gpu)
+@info "Time for mortar_flux! on CPU"
+@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
+                              Trixi.have_nonconservative_terms(equations), equations,
+                              solver.mortar, solver.surface_integral, solver, cache)
 
-# # Surface integral
-# @info "Time for surface_integral! on GPU"
-# CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for surface_integral! on CPU"
-# @time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-#                                    solver, cache)
+# Surface integral
+@info "Time for surface_integral! on GPU"
+CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+@info "Time for surface_integral! on CPU"
+@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
+                                   solver, cache)
 
-# # Jacobian
-# @info "Time for jacobian! on GPU"
-# CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-# @info "Time for jacobian! on CPU"
-# @time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
+# Jacobian
+@info "Time for jacobian! on GPU"
+CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
+@info "Time for jacobian! on CPU"
+@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
 
-# # Sources terms
-# @info "Time for sources! on GPU"
-# CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-#                                    equations_gpu, cache_gpu)
-# @info "Time for sources! on CPU"
-# @time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+# Sources terms
+@info "Time for sources! on GPU"
+CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
+                                   equations_gpu, cache_gpu)
+@info "Time for sources! on CPU"
+@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
 
-# # Semidiscretization process
-# @info "Time for rhs! on GPU"
-# CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-#                               boundary_conditions_gpu, source_terms_gpu,
-#                               solver_gpu, cache_gpu)
-# @info "Time for rhs! on CPU"
-# @time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-#                  solver, cache)
+# Semidiscretization process
+@info "Time for rhs! on GPU"
+CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
+                              boundary_conditions_gpu, source_terms_gpu,
+                              solver_gpu, cache_gpu)
+@info "Time for rhs! on CPU"
+@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
+                 solver, cache)

--- a/benchmark/benchmark_2d.jl
+++ b/benchmark/benchmark_2d.jl
@@ -59,98 +59,107 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-# Reset du
-@info "Time for reset_du! on GPU"
-CUDA.@time TrixiCUDA.reset_du!(du_gpu)
-@info "Time for reset_du! on CPU"
-@time Trixi.reset_du!(du, solver, cache)
+@info "Time for reset_du! and volume_integral! on GPU"
+@benchmark begin
+    CUDA.@sync TrixiCUDA.reset_du!(du_gpu)
+    CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                               Trixi.have_nonconservative_terms(equations_gpu),
+                                               equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                               cache_gpu)
+end
 
-# Volume integral
-@info "Time for volume_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                           Trixi.have_nonconservative_terms(equations_gpu),
-                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                           cache_gpu)
-@info "Time for volume_integral! on CPU"
-@time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                  equations, solver.volume_integral, solver, cache)
+# # Reset du
+# @info "Time for reset_du! on GPU"
+# CUDA.@time TrixiCUDA.reset_du!(du_gpu)
+# @info "Time for reset_du! on CPU"
+# @time Trixi.reset_du!(du, solver, cache)
 
-# Prolong to interfaces
-@info "Time for prolong2interfaces! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for prolong2interfaces! on CPU"
-@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
+# # Volume integral
+# @info "Time for volume_integral! on GPU"
+# CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+#                                            Trixi.have_nonconservative_terms(equations_gpu),
+#                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
+#                                            cache_gpu)
+# @info "Time for volume_integral! on CPU"
+# @time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+#                                   equations, solver.volume_integral, solver, cache)
 
-# Interface flux
-@info "Time for interface_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-                                          Trixi.have_nonconservative_terms(equations_gpu),
-                                          equations_gpu, solver_gpu, cache_gpu)
-@info "Time for interface_flux! on CPU"
-@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-                                 Trixi.have_nonconservative_terms(equations), equations,
-                                 solver.surface_integral, solver, cache)
+# # Prolong to interfaces
+# @info "Time for prolong2interfaces! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
+# @info "Time for prolong2interfaces! on CPU"
+# @time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# Prolong to boundaries
-@info "Time for prolong2boundaries! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-                                              equations_gpu, cache_gpu)
-@info "Time for prolong2boundaries! on CPU"
-@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
+# # Interface flux
+# @info "Time for interface_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
+#                                           Trixi.have_nonconservative_terms(equations_gpu),
+#                                           equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for interface_flux! on CPU"
+# @time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
+#                                  Trixi.have_nonconservative_terms(equations), equations,
+#                                  solver.surface_integral, solver, cache)
 
-# Boundary flux
-@info "Time for boundary_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-                                         Trixi.have_nonconservative_terms(equations_gpu),
-                                         equations_gpu, solver_gpu, cache_gpu)
-@info "Time for boundary_flux! on CPU"
-@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-                                solver.surface_integral, solver)
+# # Prolong to boundaries
+# @info "Time for prolong2boundaries! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
+#                                               equations_gpu, cache_gpu)
+# @info "Time for prolong2boundaries! on CPU"
+# @time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# Prolong to mortars
-@info "Time for prolong2mortars! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-                                           TrixiCUDA.check_cache_mortars(cache_gpu),
-                                           solver_gpu, cache_gpu)
-@info "Time for prolong2mortars! on CPU"
-@time Trixi.prolong2mortars!(cache, u, mesh, equations,
-                             solver.mortar, solver.surface_integral, solver)
+# # Boundary flux
+# @info "Time for boundary_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
+#                                          Trixi.have_nonconservative_terms(equations_gpu),
+#                                          equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for boundary_flux! on CPU"
+# @time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
+#                                 solver.surface_integral, solver)
 
-# Mortar flux
-@info "Time for mortar_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-                                       Trixi.have_nonconservative_terms(equations_gpu),
-                                       equations_gpu, solver_gpu, cache_gpu)
-@info "Time for mortar_flux! on CPU"
-@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-                              Trixi.have_nonconservative_terms(equations), equations,
-                              solver.mortar, solver.surface_integral, solver, cache)
+# # Prolong to mortars
+# @info "Time for prolong2mortars! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
+#                                            TrixiCUDA.check_cache_mortars(cache_gpu),
+#                                            solver_gpu, cache_gpu)
+# @info "Time for prolong2mortars! on CPU"
+# @time Trixi.prolong2mortars!(cache, u, mesh, equations,
+#                              solver.mortar, solver.surface_integral, solver)
 
-# Surface integral
-@info "Time for surface_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-@info "Time for surface_integral! on CPU"
-@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-                                   solver, cache)
+# # Mortar flux
+# @info "Time for mortar_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
+#                                        Trixi.have_nonconservative_terms(equations_gpu),
+#                                        equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for mortar_flux! on CPU"
+# @time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
+#                               Trixi.have_nonconservative_terms(equations), equations,
+#                               solver.mortar, solver.surface_integral, solver, cache)
 
-# Jacobian
-@info "Time for jacobian! on GPU"
-CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for jacobian! on CPU"
-@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
+# # Surface integral
+# @info "Time for surface_integral! on GPU"
+# CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for surface_integral! on CPU"
+# @time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
+#                                    solver, cache)
 
-# Sources terms
-@info "Time for sources! on GPU"
-CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-                                   equations_gpu, cache_gpu)
-@info "Time for sources! on CPU"
-@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+# # Jacobian
+# @info "Time for jacobian! on GPU"
+# CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
+# @info "Time for jacobian! on CPU"
+# @time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
 
-# Semidiscretization process
-@info "Time for rhs! on GPU"
-CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-                              boundary_conditions_gpu, source_terms_gpu,
-                              solver_gpu, cache_gpu)
-@info "Time for rhs! on CPU"
-@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-                 solver, cache)
+# # Sources terms
+# @info "Time for sources! on GPU"
+# CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
+#                                    equations_gpu, cache_gpu)
+# @info "Time for sources! on CPU"
+# @time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+
+# # Semidiscretization process
+# @info "Time for rhs! on GPU"
+# CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
+#                               boundary_conditions_gpu, source_terms_gpu,
+#                               solver_gpu, cache_gpu)
+# @info "Time for rhs! on CPU"
+# @time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
+#                  solver, cache)

--- a/benchmark/benchmark_3d.jl
+++ b/benchmark/benchmark_3d.jl
@@ -63,98 +63,107 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-# Reset du
-@info "Time for reset_du! on GPU"
-CUDA.@time TrixiCUDA.reset_du!(du_gpu)
-@info "Time for reset_du! on CPU"
-@time Trixi.reset_du!(du, solver, cache)
+@info "Time for reset_du! and volume_integral! on GPU"
+@benchmark begin
+    CUDA.@sync TrixiCUDA.reset_du!(du_gpu)
+    CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                               Trixi.have_nonconservative_terms(equations_gpu),
+                                               equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                               cache_gpu)
+end
 
-# Volume integral
-@info "Time for volume_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                           Trixi.have_nonconservative_terms(equations_gpu),
-                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                           cache_gpu)
-@info "Time for volume_integral! on CPU"
-@time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                  equations, solver.volume_integral, solver, cache)
+# # Reset du
+# @info "Time for reset_du! on GPU"
+# CUDA.@time TrixiCUDA.reset_du!(du_gpu)
+# @info "Time for reset_du! on CPU"
+# @time Trixi.reset_du!(du, solver, cache)
 
-# Prolong to interfaces
-@info "Time for prolong2interfaces! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for prolong2interfaces! on CPU"
-@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
+# # Volume integral
+# @info "Time for volume_integral! on GPU"
+# CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+#                                            Trixi.have_nonconservative_terms(equations_gpu),
+#                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
+#                                            cache_gpu)
+# @info "Time for volume_integral! on CPU"
+# @time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+#                                   equations, solver.volume_integral, solver, cache)
 
-# Interface flux
-@info "Time for interface_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-                                          Trixi.have_nonconservative_terms(equations_gpu),
-                                          equations_gpu, solver_gpu, cache_gpu)
-@info "Time for interface_flux! on CPU"
-@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-                                 Trixi.have_nonconservative_terms(equations), equations,
-                                 solver.surface_integral, solver, cache)
+# # Prolong to interfaces
+# @info "Time for prolong2interfaces! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
+# @info "Time for prolong2interfaces! on CPU"
+# @time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# Prolong to boundaries
-@info "Time for prolong2boundaries! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-                                              equations_gpu, cache_gpu)
-@info "Time for prolong2boundaries! on CPU"
-@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
+# # Interface flux
+# @info "Time for interface_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
+#                                           Trixi.have_nonconservative_terms(equations_gpu),
+#                                           equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for interface_flux! on CPU"
+# @time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
+#                                  Trixi.have_nonconservative_terms(equations), equations,
+#                                  solver.surface_integral, solver, cache)
 
-# Boundary flux
-@info "Time for boundary_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-                                         Trixi.have_nonconservative_terms(equations_gpu),
-                                         equations_gpu, solver_gpu, cache_gpu)
-@info "Time for boundary_flux! on CPU"
-@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-                                solver.surface_integral, solver)
+# # Prolong to boundaries
+# @info "Time for prolong2boundaries! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
+#                                               equations_gpu, cache_gpu)
+# @info "Time for prolong2boundaries! on CPU"
+# @time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# Prolong to mortars
-@info "Time for prolong2mortars! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-                                           TrixiCUDA.check_cache_mortars(cache_gpu),
-                                           solver_gpu, cache_gpu)
-@info "Time for prolong2mortars! on CPU"
-@time Trixi.prolong2mortars!(cache, u, mesh, equations,
-                             solver.mortar, solver.surface_integral, solver)
+# # Boundary flux
+# @info "Time for boundary_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
+#                                          Trixi.have_nonconservative_terms(equations_gpu),
+#                                          equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for boundary_flux! on CPU"
+# @time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
+#                                 solver.surface_integral, solver)
 
-# Mortar flux
-@info "Time for mortar_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-                                       Trixi.have_nonconservative_terms(equations_gpu),
-                                       equations_gpu, solver_gpu, cache_gpu)
-@info "Time for mortar_flux! on CPU"
-@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-                              Trixi.have_nonconservative_terms(equations), equations,
-                              solver.mortar, solver.surface_integral, solver, cache)
+# # Prolong to mortars
+# @info "Time for prolong2mortars! on GPU"
+# CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
+#                                            TrixiCUDA.check_cache_mortars(cache_gpu),
+#                                            solver_gpu, cache_gpu)
+# @info "Time for prolong2mortars! on CPU"
+# @time Trixi.prolong2mortars!(cache, u, mesh, equations,
+#                              solver.mortar, solver.surface_integral, solver)
 
-# Surface integral
-@info "Time for surface_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-@info "Time for surface_integral! on CPU"
-@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-                                   solver, cache)
+# # Mortar flux
+# @info "Time for mortar_flux! on GPU"
+# CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
+#                                        Trixi.have_nonconservative_terms(equations_gpu),
+#                                        equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for mortar_flux! on CPU"
+# @time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
+#                               Trixi.have_nonconservative_terms(equations), equations,
+#                               solver.mortar, solver.surface_integral, solver, cache)
 
-# Jacobian
-@info "Time for jacobian! on GPU"
-CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for jacobian! on CPU"
-@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
+# # Surface integral
+# @info "Time for surface_integral! on GPU"
+# CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+# @info "Time for surface_integral! on CPU"
+# @time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
+#                                    solver, cache)
 
-# Sources terms
-@info "Time for sources! on GPU"
-CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-                                   equations_gpu, cache_gpu)
-@info "Time for sources! on CPU"
-@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+# # Jacobian
+# @info "Time for jacobian! on GPU"
+# CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
+# @info "Time for jacobian! on CPU"
+# @time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
 
-# Semidiscretization process
-@info "Time for rhs! on GPU"
-CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-                              boundary_conditions_gpu, source_terms_gpu,
-                              solver_gpu, cache_gpu)
-@info "Time for rhs! on CPU"
-@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-                 solver, cache)
+# # Sources terms
+# @info "Time for sources! on GPU"
+# CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
+#                                    equations_gpu, cache_gpu)
+# @info "Time for sources! on CPU"
+# @time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+
+# # Semidiscretization process
+# @info "Time for rhs! on GPU"
+# CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
+#                               boundary_conditions_gpu, source_terms_gpu,
+#                               solver_gpu, cache_gpu)
+# @info "Time for rhs! on CPU"
+# @time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
+#                  solver, cache)

--- a/benchmark/benchmark_3d.jl
+++ b/benchmark/benchmark_3d.jl
@@ -63,107 +63,101 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-@info "Time for reset_du! and volume_integral! on GPU"
-@benchmark begin
-    CUDA.@sync TrixiCUDA.reset_du!(du_gpu)
-    CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                               Trixi.have_nonconservative_terms(equations_gpu),
-                                               equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                               cache_gpu)
-end
-
 # # Reset du
 # @info "Time for reset_du! on GPU"
 # CUDA.@time TrixiCUDA.reset_du!(du_gpu)
 # @info "Time for reset_du! on CPU"
 # @time Trixi.reset_du!(du, solver, cache)
 
-# # Volume integral
-# @info "Time for volume_integral! on GPU"
-# CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-#                                            Trixi.have_nonconservative_terms(equations_gpu),
-#                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
-#                                            cache_gpu)
-# @info "Time for volume_integral! on CPU"
-# @time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-#                                   equations, solver.volume_integral, solver, cache)
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
+CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                           Trixi.have_nonconservative_terms(equations_gpu),
+                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                           cache_gpu)
+@info "Time for reset_du! and volume_integral! on CPU"
+@time begin
+    Trixi.reset_du!(du, solver, cache)
+    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+                                equations, solver.volume_integral, solver, cache)
+end
 
-# # Prolong to interfaces
-# @info "Time for prolong2interfaces! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-# @info "Time for prolong2interfaces! on CPU"
-# @time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
+# Prolong to interfaces
+@info "Time for prolong2interfaces! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
+@info "Time for prolong2interfaces! on CPU"
+@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# # Interface flux
-# @info "Time for interface_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-#                                           Trixi.have_nonconservative_terms(equations_gpu),
-#                                           equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for interface_flux! on CPU"
-# @time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-#                                  Trixi.have_nonconservative_terms(equations), equations,
-#                                  solver.surface_integral, solver, cache)
+# Interface flux
+@info "Time for interface_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
+                                          Trixi.have_nonconservative_terms(equations_gpu),
+                                          equations_gpu, solver_gpu, cache_gpu)
+@info "Time for interface_flux! on CPU"
+@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
+                                 Trixi.have_nonconservative_terms(equations), equations,
+                                 solver.surface_integral, solver, cache)
 
-# # Prolong to boundaries
-# @info "Time for prolong2boundaries! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-#                                               equations_gpu, cache_gpu)
-# @info "Time for prolong2boundaries! on CPU"
-# @time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
+# Prolong to boundaries
+@info "Time for prolong2boundaries! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
+                                              equations_gpu, cache_gpu)
+@info "Time for prolong2boundaries! on CPU"
+@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
 
-# # Boundary flux
-# @info "Time for boundary_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-#                                          Trixi.have_nonconservative_terms(equations_gpu),
-#                                          equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for boundary_flux! on CPU"
-# @time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-#                                 solver.surface_integral, solver)
+# Boundary flux
+@info "Time for boundary_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
+                                         Trixi.have_nonconservative_terms(equations_gpu),
+                                         equations_gpu, solver_gpu, cache_gpu)
+@info "Time for boundary_flux! on CPU"
+@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
+                                solver.surface_integral, solver)
 
-# # Prolong to mortars
-# @info "Time for prolong2mortars! on GPU"
-# CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-#                                            TrixiCUDA.check_cache_mortars(cache_gpu),
-#                                            solver_gpu, cache_gpu)
-# @info "Time for prolong2mortars! on CPU"
-# @time Trixi.prolong2mortars!(cache, u, mesh, equations,
-#                              solver.mortar, solver.surface_integral, solver)
+# Prolong to mortars
+@info "Time for prolong2mortars! on GPU"
+CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
+                                           TrixiCUDA.check_cache_mortars(cache_gpu),
+                                           solver_gpu, cache_gpu)
+@info "Time for prolong2mortars! on CPU"
+@time Trixi.prolong2mortars!(cache, u, mesh, equations,
+                             solver.mortar, solver.surface_integral, solver)
 
-# # Mortar flux
-# @info "Time for mortar_flux! on GPU"
-# CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-#                                        Trixi.have_nonconservative_terms(equations_gpu),
-#                                        equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for mortar_flux! on CPU"
-# @time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-#                               Trixi.have_nonconservative_terms(equations), equations,
-#                               solver.mortar, solver.surface_integral, solver, cache)
+# Mortar flux
+@info "Time for mortar_flux! on GPU"
+CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
+                                       Trixi.have_nonconservative_terms(equations_gpu),
+                                       equations_gpu, solver_gpu, cache_gpu)
+@info "Time for mortar_flux! on CPU"
+@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
+                              Trixi.have_nonconservative_terms(equations), equations,
+                              solver.mortar, solver.surface_integral, solver, cache)
 
-# # Surface integral
-# @info "Time for surface_integral! on GPU"
-# CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-# @info "Time for surface_integral! on CPU"
-# @time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-#                                    solver, cache)
+# Surface integral
+@info "Time for surface_integral! on GPU"
+CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+@info "Time for surface_integral! on CPU"
+@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
+                                   solver, cache)
 
-# # Jacobian
-# @info "Time for jacobian! on GPU"
-# CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-# @info "Time for jacobian! on CPU"
-# @time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
+# Jacobian
+@info "Time for jacobian! on GPU"
+CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
+@info "Time for jacobian! on CPU"
+@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
 
-# # Sources terms
-# @info "Time for sources! on GPU"
-# CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-#                                    equations_gpu, cache_gpu)
-# @info "Time for sources! on CPU"
-# @time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
+# Sources terms
+@info "Time for sources! on GPU"
+CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
+                                   equations_gpu, cache_gpu)
+@info "Time for sources! on CPU"
+@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
 
-# # Semidiscretization process
-# @info "Time for rhs! on GPU"
-# CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-#                               boundary_conditions_gpu, source_terms_gpu,
-#                               solver_gpu, cache_gpu)
-# @info "Time for rhs! on CPU"
-# @time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-#                  solver, cache)
+# Semidiscretization process
+@info "Time for rhs! on GPU"
+CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
+                              boundary_conditions_gpu, source_terms_gpu,
+                              solver_gpu, cache_gpu)
+@info "Time for rhs! on CPU"
+@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
+                 solver, cache)

--- a/benchmark/example.jl
+++ b/benchmark/example.jl
@@ -50,21 +50,24 @@ ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-# Reset du
-@info "Time for reset_du! on GPU"
-CUDA.@time TrixiCUDA.reset_du!(du_gpu)
-@info "Time for reset_du! on CPU"
-@time Trixi.reset_du!(du, solver, cache)
+# # Reset du
+# @info "Time for reset_du! on GPU"
+# CUDA.@time TrixiCUDA.reset_du!(du_gpu)
+# @info "Time for reset_du! on CPU"
+# @time Trixi.reset_du!(du, solver, cache)
 
-# Volume integral
-@info "Time for volume_integral! on GPU"
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
 CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                            Trixi.have_nonconservative_terms(equations_gpu),
                                            equations_gpu, solver_gpu.volume_integral, solver_gpu,
                                            cache_gpu)
-@info "Time for volume_integral! on CPU"
-@time Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                  equations, solver.volume_integral, solver, cache)
+@info "Time for reset_du! and volume_integral! on CPU"
+@time begin
+    Trixi.reset_du!(du, solver, cache)
+    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
+                                equations, solver.volume_integral, solver, cache)
+end
 
 # Prolong to interfaces
 @info "Time for prolong2interfaces! on GPU"

--- a/profile/profiling.jl
+++ b/profile/profiling.jl
@@ -45,7 +45,8 @@ du_gpu = similar(u_gpu)
 
 # Semidiscretization process
 # Reset du test
-TrixiCUDA.reset_du!(du_gpu)
+# Function `reset_du!` is deprecated see https://github.com/trixi-gpu/TrixiCUDA.jl/pull/100
+# TrixiCUDA.reset_du!(du_gpu)
 
 # Volume integral test
 TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/src/solvers/common.jl
+++ b/src/solvers/common.jl
@@ -1,12 +1,13 @@
 # Some common functions that are shared between the solvers.
 
 # Copy data from CPU to GPU
-function reset_du!(du::CuArray)
-    du_zero = zero(du)
-    du .= du_zero # no scalar indexing
+# Function `reset_du!` is deprecated see https://github.com/trixi-gpu/TrixiCUDA.jl/pull/100
+# function reset_du!(du::CuArray)
+#     du_zero = zero(du)
+#     du .= du_zero # no scalar indexing
 
-    return nothing
-end
+#     return nothing
+# end
 
 # Set diagonal entries of a matrix to zeros
 function set_diagonal_to_zero!(A::Array)

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -29,6 +29,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr)
     k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
 
     if (i <= size(du, 1) && j <= size(du, 2) && k <= size(du, 3))
+        @inbounds du[i, j, k] = zero(eltype(du)) # fuse `reset_du!` here 
         for ii in axes(du, 2)
             @inbounds du[i, j, k] += derivative_dhat[j, ii] * flux_arr[i, ii, k]
         end
@@ -97,6 +98,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr,
     k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
 
     if (i <= size(du, 1) && j <= size(du, 2) && k <= size(du, 3))
+        @inbounds du[i, j, k] = zero(eltype(du)) # fuse `reset_du!` here
         for ii in axes(du, 2)
             @inbounds du[i, j, k] += derivative_split[j, ii] * volume_flux_arr[i, j, ii, k]
         end
@@ -112,6 +114,7 @@ function volume_integral_kernel!(du, derivative_split, symmetric_flux_arr, nonco
     k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
 
     if (i <= size(du, 1) && j <= size(du, 2) && k <= size(du, 3))
+        @inbounds du[i, j, k] = zero(eltype(du)) # fuse `reset_du!` here
         integral_contribution = zero(eltype(du))
 
         for ii in axes(du, 2)
@@ -181,6 +184,8 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
     if (i <= size(du, 1) && j <= size(du, 2) && k <= size(du, 3))
         # length(element_ids_dg) == size(du, 3)
         # length(element_ids_dgfv) == size(du, 3)
+        @inbounds du[i, j, k] = zero(eltype(du)) # fuse `reset_du!` here
+
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero
             element_dgfv = element_ids_dgfv[k] # check if `element_dgfv` is zero
@@ -270,6 +275,7 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
     if (i <= size(du, 1) && j <= size(du, 2) && k <= size(du, 3))
         # length(element_ids_dg) == size(du, 3)
         # length(element_ids_dgfv) == size(du, 3)
+        @inbounds du[i, j, k] = zero(eltype(du)) # fuse `reset_du!` here
 
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -1076,7 +1076,9 @@ end
 # See also `rhs!` function in Trixi.jl
 function rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
                   source_terms::Source, dg::DGSEM, cache) where {Source}
-    reset_du!(du)
+    # reset_du!(du) 
+    # reset_du!(du) is now fused into the next kernel, 
+    # removing the need for a separate function call.
 
     cuda_volume_integral!(du, u, mesh, have_nonconservative_terms(equations), equations,
                           dg.volume_integral, dg, cache)

--- a/test/tree_dgsem_1d/advection_basic.jl
+++ b/test/tree_dgsem_1d/advection_basic.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/advection_extended.jl
+++ b/test/tree_dgsem_1d/advection_extended.jl
@@ -57,9 +57,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/burgers_basic.jl
+++ b/test/tree_dgsem_1d/burgers_basic.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/burgers_rarefraction.jl
+++ b/test/tree_dgsem_1d/burgers_rarefraction.jl
@@ -90,9 +90,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/burgers_shock.jl
+++ b/test/tree_dgsem_1d/burgers_shock.jl
@@ -91,9 +91,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/euler_blast_wave.jl
+++ b/test/tree_dgsem_1d/euler_blast_wave.jl
@@ -75,9 +75,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/euler_ec.jl
+++ b/test/tree_dgsem_1d/euler_ec.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/euler_shock.jl
+++ b/test/tree_dgsem_1d/euler_shock.jl
@@ -61,9 +61,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/euler_source_terms.jl
+++ b/test/tree_dgsem_1d/euler_source_terms.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
@@ -59,9 +59,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/eulermulti_ec.jl
+++ b/test/tree_dgsem_1d/eulermulti_ec.jl
@@ -58,9 +58,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/eulermulti_es.jl
+++ b/test/tree_dgsem_1d/eulermulti_es.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/eulerquasi_ec.jl
+++ b/test/tree_dgsem_1d/eulerquasi_ec.jl
@@ -62,9 +62,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/eulerquasi_source_terms.jl
+++ b/test/tree_dgsem_1d/eulerquasi_source_terms.jl
@@ -55,9 +55,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
@@ -71,9 +71,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
@@ -57,9 +57,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_1d/mhd_alfven_wave.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/mhd_ec.jl
+++ b/test/tree_dgsem_1d/mhd_ec.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_1d/shallowwater_shock.jl
+++ b/test/tree_dgsem_1d/shallowwater_shock.jl
@@ -94,9 +94,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/advection_basic.jl
+++ b/test/tree_dgsem_2d/advection_basic.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/advection_mortar.jl
+++ b/test/tree_dgsem_2d/advection_mortar.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/euler_blob_mortar.jl
+++ b/test/tree_dgsem_2d/euler_blob_mortar.jl
@@ -96,9 +96,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -61,9 +61,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/euler_source_terms.jl
+++ b/test/tree_dgsem_2d/euler_source_terms.jl
@@ -51,9 +51,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
@@ -61,9 +61,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/eulermulti_ec.jl
+++ b/test/tree_dgsem_2d/eulermulti_ec.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/eulermulti_es.jl
+++ b/test/tree_dgsem_2d/eulermulti_es.jl
@@ -58,9 +58,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
@@ -60,9 +60,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave.jl
@@ -54,9 +54,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
@@ -58,9 +58,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -64,9 +64,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/shallowwater_ec.jl
+++ b/test/tree_dgsem_2d/shallowwater_ec.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/shallowwater_source_terms.jl
+++ b/test/tree_dgsem_2d/shallowwater_source_terms.jl
@@ -56,9 +56,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
@@ -60,9 +60,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/advection_basic.jl
+++ b/test/tree_dgsem_3d/advection_basic.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/advection_mortar.jl
+++ b/test/tree_dgsem_3d/advection_mortar.jl
@@ -55,9 +55,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/euler_convergence.jl
+++ b/test/tree_dgsem_3d/euler_convergence.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/euler_ec.jl
+++ b/test/tree_dgsem_3d/euler_ec.jl
@@ -52,9 +52,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/euler_mortar.jl
+++ b/test/tree_dgsem_3d/euler_mortar.jl
@@ -54,9 +54,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -63,9 +63,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/euler_source_terms.jl
+++ b/test/tree_dgsem_3d/euler_source_terms.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
@@ -61,9 +61,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
@@ -57,9 +57,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/mhd_ec.jl
+++ b/test/tree_dgsem_3d/mhd_ec.jl
@@ -53,9 +53,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -64,9 +64,11 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    TrixiCUDA.reset_du!(du_gpu)
+    # TrixiCUDA.reset_du!(du_gpu)
+    # Trixi.reset_du!(du, solver, cache)
+    # @test_approx (du_gpu, du)
+
     Trixi.reset_du!(du, solver, cache)
-    @test_approx (du_gpu, du)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),


### PR DESCRIPTION
The benchmark shows that `reset_du!` causes 1 GPU allocation of 640.000 KiB and takes 1.37% of memory management time (using the example of Euler shock capturing in 3D). This overhead can be eliminated by fusing the `reset_du!` function into the subsequent volume integral kernels.

Please ensure that the new benchmark results are provided before merging.