### PR TITLE
Load package with device property querying

### DIFF
--- a/src/TrixiCUDA.jl
+++ b/src/TrixiCUDA.jl
@@ -7,22 +7,19 @@ using CUDA
 using CUDA: @cuda, CuArray, HostKernel,
             threadIdx, blockIdx, blockDim, similar, launch_configuration
 
-using Trixi: AbstractEquations, AbstractContainer, AbstractSemidiscretization, AbstractMesh,
+using Trixi: AbstractEquations, AbstractContainer, AbstractMesh, AbstractSemidiscretization,
+             True, False, TreeMesh, DGSEM, SemidiscretizationHyperbolic,
              ElementContainer1D, ElementContainer2D, ElementContainer3D,
              InterfaceContainer1D, InterfaceContainer2D, InterfaceContainer3D,
              BoundaryContainer1D, BoundaryContainer2D, BoundaryContainer3D,
-             L2MortarContainer2D, L2MortarContainer3D,
-             True, False,
-             TreeMesh, DGSEM,
-             SemidiscretizationHyperbolic,
+             LobattoLegendreMortarL2, L2MortarContainer2D, L2MortarContainer3D,
              BoundaryConditionPeriodic, BoundaryConditionDirichlet,
              VolumeIntegralWeakForm, VolumeIntegralFluxDifferencing, VolumeIntegralShockCapturingHG,
-             LobattoLegendreMortarL2,
              allocate_coefficients, mesh_equations_solver_cache,
              flux, ntuple, nvariables, nnodes, nelements, nmortars,
              local_leaf_cells, init_elements, init_interfaces, init_boundaries, init_mortars,
-             wrap_array, compute_coefficients, have_nonconservative_terms,
-             boundary_condition_periodic,
+             wrap_array, compute_coefficients,
+             have_nonconservative_terms, boundary_condition_periodic,
              digest_boundary_conditions, check_periodicity_mesh_boundary_conditions,
              set_log_type!, set_sqrt_type!
 
@@ -33,7 +30,8 @@ using SciMLBase: ODEProblem, FullSpecialize
 
 using StaticArrays: SVector
 
-# Change to use the Base.log and Base.sqrt - need to be fixed to avoid outputs
+# Change to use the Base.log and Base.sqrt 
+# FIXME: Need to be fixed to avoid precompilation outputs
 set_log_type!("log_Base")
 set_sqrt_type!("sqrt_Base")
 
@@ -45,5 +43,12 @@ include("solvers/solvers.jl")
 # Export the public APIs
 export SemidiscretizationHyperbolicGPU
 export semidiscretizeGPU
+
+# Get called every time the package is loaded
+function __init__()
+
+    # Initialize the device properties
+    init_device()
+end
 
 end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -13,7 +13,7 @@ function init_device()
         global MAX_THREADS_PER_BLOCK = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
     catch e
         # Handle the errors
-        if e isa CUDA.Error
+        if e isa CUDA.CuError
             println("Error initializing device: ", e.msg)
             println("Ensure a CUDA-enabled GPU is available and properly configured.")
         else

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -1,2 +1,15 @@
 include("configurators.jl")
 include("stable.jl")
+
+# Initialize the device properties
+function init_device()
+    # Consider single GPU for now
+    # TODO: Consider multiple GPUs later
+    device = CUDA.device()
+
+    # Get the device properties
+    global MULTIPROCESSOR_COUNT = CUDA.attribute(device,
+                                                 CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
+    global MAX_THREADS_PER_BLOCK = CUDA.attribute(device,
+                                                  CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+end

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -3,13 +3,25 @@ include("stable.jl")
 
 # Initialize the device properties
 function init_device()
-    # Consider single GPU for now
-    # TODO: Consider multiple GPUs later
-    device = CUDA.device()
+    try
+        # Consider single GPU for now
+        # TODO: Consider multiple GPUs later
+        device = CUDA.device()
 
-    # Get the device properties
-    global MULTIPROCESSOR_COUNT = CUDA.attribute(device,
-                                                 CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
-    global MAX_THREADS_PER_BLOCK = CUDA.attribute(device,
-                                                  CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+        # Get the device properties
+        global MULTIPROCESSOR_COUNT = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
+        global MAX_THREADS_PER_BLOCK = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+    catch e
+        # Handle the errors
+        if e isa CUDA.Error
+            println("Error initializing device: ", e.msg)
+            println("Ensure a CUDA-enabled GPU is available and properly configured.")
+        else
+            println("An unexpected error occurred: ", e)
+        end
+
+        # Fall back to set default values
+        global MULTIPROCESSOR_COUNT = 0
+        global MAX_THREADS_PER_BLOCK = 0
+    end
 end

--- a/src/auxiliary/configurators.jl
+++ b/src/auxiliary/configurators.jl
@@ -18,12 +18,9 @@ end
 # to use stride loops to handle the constrained launch size.
 function kernel_configurator_coop_1d(kernel::HostKernel, x::Int)
     # config = launch_configuration(kernel.fun) # not used in this case
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    sm_count = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT) # get number of SMs
 
     threads = 32 # warp size is 32, if block size is less than 32, it will be padded to 32
-    blocks = min(cld(x, threads), sm_count)
+    blocks = min(cld(x, threads), MULTIPROCESSOR_COUNT)
 
     return (threads = threads, blocks = blocks)
 end
@@ -53,9 +50,6 @@ end
 # to use stride loops to handle the constrained launch size.
 function kernel_configurator_coop_2d(kernel::HostKernel, x::Int, y::Int)
     config = launch_configuration(kernel.fun) # get the number of threads
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    sm_count = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT) # get number of SMs
 
     # y dimension
     dims_y1 = cld(x * y, 32)
@@ -66,7 +60,7 @@ function kernel_configurator_coop_2d(kernel::HostKernel, x::Int, y::Int)
     # x dimension is hard-coded to warp size 32
     threads = (32, dims_y)
     blocks_x = cld(x, threads[1])
-    blocks_y = min(cld(y, threads[2]), fld(sm_count, blocks_x))
+    blocks_y = min(cld(y, threads[2]), fld(MULTIPROCESSOR_COUNT, blocks_x))
 
     blocks = (blocks_x, blocks_y)
 
@@ -104,9 +98,6 @@ end
 # to use stride loops to handle the constrained launch size.
 function kernel_configurator_coop_3d(kernel::HostKernel, x::Int, y::Int, z::Int)
     config = launch_configuration(kernel.fun) # get the number of threads
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    sm_count = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT) # get number of SMs
 
     # y dimension
     dims_y1 = cld(x * y, 32)
@@ -123,8 +114,8 @@ function kernel_configurator_coop_3d(kernel::HostKernel, x::Int, y::Int, z::Int)
     # x dimension is hard-coded to warp size 32
     threads = (32, dims_y, dims_z)
     blocks_x = cld(x, threads[1])
-    blocks_y = min(cld(y, threads[2]), fld(sm_count, blocks_x))
-    blocks_z = min(cld(z, threads[3]), fld(sm_count, blocks_x * blocks_y))
+    blocks_y = min(cld(y, threads[2]), fld(MULTIPROCESSOR_COUNT, blocks_x))
+    blocks_z = min(cld(z, threads[3]), fld(MULTIPROCESSOR_COUNT, blocks_x * blocks_y))
 
     blocks = (blocks_x, blocks_y, blocks_z)
 

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -675,18 +675,13 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
                                equations, volume_integral::VolumeIntegralWeakForm, dg::DGSEM, cache)
     derivative_dhat = CuArray(dg.basis.derivative_dhat)
 
-    # Query hardware properties
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    max_thread_per_block = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-
     # The maximum number of threads per block is the dominant factor when choosing the optimization 
     # method. However, there are other factors that may cause a launch failure, such as the maximum 
     # number of registers per block. Here, we have omitted all other factors, but this should be 
     # enhanced later for a safer kernel launch.
     # TODO: More checks before the kernel launch
     thread_num_per_block = size(du, 1) * size(du, 2)^2
-    if thread_num_per_block > max_thread_per_block
+    if thread_num_per_block > MAX_THREADS_PER_BLOCK
         # TODO: How to optimize when size is large
         flux_arr = similar(u)
 

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -1127,18 +1127,13 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, 
                                volume_integral::VolumeIntegralWeakForm, dg::DGSEM, cache)
     derivative_dhat = CuArray(dg.basis.derivative_dhat)
 
-    # Query hardware properties
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    max_thread_per_block = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-
     # The maximum number of threads per block is the dominant factor when choosing the optimization 
     # method. However, there are other factors that may cause a launch failure, such as the maximum 
     # number of registers per block. Here, we have omitted all other factors, but this should be 
     # enhanced later for a safer kernel launch.
     # TODO: More checks before the kernel launch
     thread_num_per_block = size(du, 1) * size(du, 2)^2
-    if thread_num_per_block > max_thread_per_block
+    if thread_num_per_block > MAX_THREADS_PER_BLOCK
         # TODO: How to optimize when size is large
         flux_arr1 = similar(u)
         flux_arr2 = similar(u)

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -1707,18 +1707,13 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, 
                                volume_integral::VolumeIntegralWeakForm, dg::DGSEM, cache)
     derivative_dhat = CuArray(dg.basis.derivative_dhat)
 
-    # Query hardware properties
-    # TODO: Maybe pack properties into a struct
-    device = CUDA.device()
-    max_thread_per_block = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
-
     # The maximum number of threads per block is the dominant factor when choosing the optimization 
     # method. However, there are other factors that may cause a launch failure, such as the maximum 
     # number of registers per block. Here, we have omitted all other factors, but this should be 
     # enhanced later for a safer kernel launch.
     # TODO: More checks before the kernel launch
     thread_num_per_block = size(du, 1) * size(du, 2)^3
-    if thread_num_per_block > max_thread_per_block
+    if thread_num_per_block > MAX_THREADS_PER_BLOCK
         # TODO: How to optimize when size is large
         flux_arr1 = similar(u)
         flux_arr2 = similar(u)


### PR DESCRIPTION
The original device property querying occurred within functions that needed them, which leads to repetitive queries throughout the solving process. Now the device property querying has been moved to the package loading process (i.e., within the `__init__` function in `TrixiCUDA.jl`) and the corresponding properties are stored globally. This saves the more time when running our solvers.

But the current querying is based on the assumption that the user is using single GPU so it needs to be enhanced to a multi-GPU system.