### PR TITLE
Remove comments for `reset_du!` function in tests

### DIFF
--- a/test/tree_dgsem_1d/advection_basic.jl
+++ b/test/tree_dgsem_1d/advection_basic.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/advection_extended.jl
+++ b/test/tree_dgsem_1d/advection_extended.jl
@@ -57,10 +57,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/burgers_basic.jl
+++ b/test/tree_dgsem_1d/burgers_basic.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/burgers_rarefraction.jl
+++ b/test/tree_dgsem_1d/burgers_rarefraction.jl
@@ -90,10 +90,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/burgers_shock.jl
+++ b/test/tree_dgsem_1d/burgers_shock.jl
@@ -91,10 +91,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/euler_blast_wave.jl
+++ b/test/tree_dgsem_1d/euler_blast_wave.jl
@@ -75,10 +75,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/euler_ec.jl
+++ b/test/tree_dgsem_1d/euler_ec.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/euler_shock.jl
+++ b/test/tree_dgsem_1d/euler_shock.jl
@@ -61,10 +61,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/euler_source_terms.jl
+++ b/test/tree_dgsem_1d/euler_source_terms.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
@@ -59,10 +59,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/eulermulti_ec.jl
+++ b/test/tree_dgsem_1d/eulermulti_ec.jl
@@ -58,10 +58,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/eulermulti_es.jl
+++ b/test/tree_dgsem_1d/eulermulti_es.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/eulerquasi_ec.jl
+++ b/test/tree_dgsem_1d/eulerquasi_ec.jl
@@ -62,10 +62,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/eulerquasi_source_terms.jl
+++ b/test/tree_dgsem_1d/eulerquasi_source_terms.jl
@@ -55,10 +55,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
@@ -71,10 +71,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
@@ -57,10 +57,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_1d/mhd_alfven_wave.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/mhd_ec.jl
+++ b/test/tree_dgsem_1d/mhd_ec.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_1d/shallowwater_shock.jl
+++ b/test/tree_dgsem_1d/shallowwater_shock.jl
@@ -94,10 +94,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/advection_basic.jl
+++ b/test/tree_dgsem_2d/advection_basic.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/advection_mortar.jl
+++ b/test/tree_dgsem_2d/advection_mortar.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/euler_blob_mortar.jl
+++ b/test/tree_dgsem_2d/euler_blob_mortar.jl
@@ -96,10 +96,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/euler_ec.jl
+++ b/test/tree_dgsem_2d/euler_ec.jl
@@ -55,10 +55,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -61,10 +61,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/euler_source_terms.jl
+++ b/test/tree_dgsem_2d/euler_source_terms.jl
@@ -51,10 +51,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
@@ -61,10 +61,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/eulermulti_ec.jl
+++ b/test/tree_dgsem_2d/eulermulti_ec.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/eulermulti_es.jl
+++ b/test/tree_dgsem_2d/eulermulti_es.jl
@@ -58,10 +58,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
@@ -60,10 +60,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave.jl
@@ -54,10 +54,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
@@ -58,10 +58,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -64,10 +64,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/shallowwater_ec.jl
+++ b/test/tree_dgsem_2d/shallowwater_ec.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/shallowwater_source_terms.jl
+++ b/test/tree_dgsem_2d/shallowwater_source_terms.jl
@@ -56,10 +56,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
@@ -60,10 +60,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/advection_basic.jl
+++ b/test/tree_dgsem_3d/advection_basic.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/advection_mortar.jl
+++ b/test/tree_dgsem_3d/advection_mortar.jl
@@ -55,10 +55,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/euler_convergence.jl
+++ b/test/tree_dgsem_3d/euler_convergence.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/euler_ec.jl
+++ b/test/tree_dgsem_3d/euler_ec.jl
@@ -52,10 +52,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/euler_mortar.jl
+++ b/test/tree_dgsem_3d/euler_mortar.jl
@@ -54,10 +54,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -63,10 +63,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/euler_source_terms.jl
+++ b/test/tree_dgsem_3d/euler_source_terms.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
@@ -61,10 +61,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
@@ -57,10 +57,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/mhd_ec.jl
+++ b/test/tree_dgsem_3d/mhd_ec.jl
@@ -53,10 +53,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -64,10 +64,6 @@ include("../test_macros.jl")
     # du is initlaizaed as undefined, cannot test now
 
     # Tests for semidiscretization process
-    # TrixiCUDA.reset_du!(du_gpu)
-    # Trixi.reset_du!(du, solver, cache)
-    # @test_approx (du_gpu, du)
-
     Trixi.reset_du!(du, solver, cache)
 
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,


### PR DESCRIPTION
The `reset_du!` function has been confirmed to be fused into volume integral kernels for better performance thus the corresponding comments can be removed.