### PR TITLE
Adapt `wrap_array` for GPU arrays 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,18 @@ Our current focus is on the semidiscretization of PDEs. The table below shows th
 
 # Example of PDE Semidiscretization on GPU
 
-⚠️ **Warning:** Due to the cache initialization process being moved to the GPU for performance optimization, most examples may raise errors because of mismatched CPU and GPU APIs. Please try the examples in the tests, as they are always the most up-to-date.
-
 Let's take a look at a simple example to see how to use TrixiCUDA.jl to run the simulation on the GPU.
 
 ```julia
 # Take 1D linear advection equation as an example
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
+
+# Curretly skip the issue of scalar indexing
+# See issues https://github.com/trixi-gpu/TrixiCUDA.jl/issues/59
+# and https://github.com/trixi-gpu/TrixiCUDA.jl/issues/113
+using CUDA
+CUDA.allowscalar(true)
 
 ###############################################################################
 # semidiscretization of the linear advection equation
@@ -93,13 +97,13 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 30_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test,
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
                                     solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.
 
-ode = semidiscretizeGPU(semi, (0.0, 1.0)) # from TrixiCUDA.jl
+ode = semidiscretizeGPU(semi, (0.0, 1.0))
 
 summary_callback = SummaryCallback()
 
@@ -121,7 +125,7 @@ sol = solve(ode, CarpenterKennedy2N54(williamson_condition = false),
 
 summary_callback()
 ```
-
+Please also try the examples in the tests directory, as they are always the most up-to-date.
 
 # Benchmarks
 Please refer to the benchmark directory to conduct your own benchmarking based on different PDE examples. The official benchmarking report for the semidiscretization process will be released in the future.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Let's take a look at a simple example to see how to use TrixiCUDA.jl to run the 
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
-# Curretly skip the issue of scalar indexing
+# Currently skip the issue of scalar indexing
 # See issues https://github.com/trixi-gpu/TrixiCUDA.jl/issues/59
 # and https://github.com/trixi-gpu/TrixiCUDA.jl/issues/113
 using CUDA

--- a/examples/advection_basic_1d.jl
+++ b/examples/advection_basic_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl 
 
 ###############################################################################
@@ -21,8 +25,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000) # set maximum capacity of tree data structure
 
 # A semidiscretization collects data structures and functions for the spatial discretization
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test,
-                                    solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
+                                       solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/advection_basic_2d.jl
+++ b/examples/advection_basic_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl 
 
 ###############################################################################
@@ -21,8 +25,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000) # set maximum capacity of tree data structure
 
 # A semidiscretization collects data structures and functions for the spatial discretization
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test,
-                                    solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
+                                       solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/advection_basic_3d.jl
+++ b/examples/advection_basic_3d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl 
 
 ###############################################################################
@@ -21,8 +25,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000) # set maximum capacity of tree data structure
 
 # A semidiscretization collects data structures and functions for the spatial discretization
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition_convergence_test,
-                                    solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
+                                       solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/advection_mortar_2d.jl
+++ b/examples/advection_mortar_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl 
 
 ###############################################################################
@@ -21,7 +25,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 refinement_patches = refinement_patches,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/advection_mortar_3d.jl
+++ b/examples/advection_mortar_3d.jl
@@ -2,6 +2,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -24,7 +28,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 refinement_patches = refinement_patches,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_ec_1d.jl
+++ b/examples/euler_ec_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -19,7 +23,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 5,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_ec_2d.jl
+++ b/examples/euler_ec_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -20,8 +24,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 10_000,
                 periodicity = true)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    boundary_conditions = boundary_condition_periodic)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       boundary_conditions = boundary_condition_periodic)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_ec_3d.jl
+++ b/examples/euler_ec_3d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -20,7 +24,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 3,
                 n_cells_max = 100_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_shockcapturing_1d.jl
+++ b/examples/euler_shockcapturing_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -29,7 +33,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 5,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_shockcapturing_2d.jl
+++ b/examples/euler_shockcapturing_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -29,7 +33,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 5,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_shockcapturing_3d.jl
+++ b/examples/euler_shockcapturing_3d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -31,7 +35,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 3,
                 n_cells_max = 100_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_source_terms_1d.jl
+++ b/examples/euler_source_terms_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -20,8 +24,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_source_terms_2d.jl
+++ b/examples/euler_source_terms_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -17,8 +21,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 4,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/euler_source_terms_3d.jl
+++ b/examples/euler_source_terms_3d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -19,8 +23,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 2,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/eulermulti_ec_1d.jl
+++ b/examples/eulermulti_ec_1d.jl
@@ -1,12 +1,21 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
 # semidiscretization of the compressible Euler multicomponent equations
-equations = CompressibleEulerMulticomponentEquations1D(gammas = (1.4, 1.4, 1.4),
-                                                       gas_constants = (0.4, 0.4, 0.4))
+
+# More than two components are not supported, this is a bug
+# equations = CompressibleEulerMulticomponentEquations1D(gammas = (1.4, 1.4, 1.4),
+#                                                        gas_constants = (0.4, 0.4, 0.4))
+
+equations = CompressibleEulerMulticomponentEquations1D(gammas = (1.4, 1.4),
+                                                       gas_constants = (0.4, 0.4))
 
 initial_condition = initial_condition_weak_blast_wave
 
@@ -20,7 +29,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 5,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/eulermulti_ec_2d.jl
+++ b/examples/eulermulti_ec_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -20,7 +24,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 initial_refinement_level = 5,
                 n_cells_max = 10_000)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/hypdiff_nonperiodic_1d.jl
+++ b/examples/hypdiff_nonperiodic_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -21,9 +25,9 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000,
                 periodicity = false)
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    boundary_conditions = boundary_conditions,
-                                    source_terms = source_terms_poisson_nonperiodic)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       boundary_conditions = boundary_conditions,
+                                       source_terms = source_terms_poisson_nonperiodic)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/hypdiff_nonperiodic_2d.jl
+++ b/examples/hypdiff_nonperiodic_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -24,9 +28,9 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000,
                 periodicity = (false, true))
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    boundary_conditions = boundary_conditions,
-                                    source_terms = source_terms_poisson_nonperiodic)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       boundary_conditions = boundary_conditions,
+                                       source_terms = source_terms_poisson_nonperiodic)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/hypdiff_nonperiodic_3d.jl
+++ b/examples/hypdiff_nonperiodic_3d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -25,9 +29,9 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 30_000,
                 periodicity = (false, true, true))
 
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_poisson_nonperiodic,
-                                    boundary_conditions = boundary_conditions)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_poisson_nonperiodic,
+                                       boundary_conditions = boundary_conditions)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/shallowwater_dirichlet_1d.jl
+++ b/examples/shallowwater_dirichlet_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -32,8 +36,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 periodicity = false)
 
 # create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    boundary_conditions = boundary_condition)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       boundary_conditions = boundary_condition)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/shallowwater_dirichlet_2d.jl
+++ b/examples/shallowwater_dirichlet_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -31,9 +35,9 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 periodicity = false)
 
 # create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    boundary_conditions = boundary_condition,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       boundary_conditions = boundary_condition,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/shallowwater_ec_1d.jl
+++ b/examples/shallowwater_ec_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 using OrdinaryDiffEq
@@ -59,7 +63,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 10_000)
 
 # Create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solver

--- a/examples/shallowwater_ec_2d.jl
+++ b/examples/shallowwater_ec_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -31,7 +35,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 n_cells_max = 10_000)
 
 # Create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
 
 ###############################################################################
 # ODE solver

--- a/examples/shallowwater_source_terms_1d.jl
+++ b/examples/shallowwater_source_terms_1d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -29,8 +33,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 periodicity = true)
 
 # create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/examples/shallowwater_source_terms_2d.jl
+++ b/examples/shallowwater_source_terms_2d.jl
@@ -1,6 +1,10 @@
 using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
+# Currently skip the issue of scalar indexing
+using CUDA
+CUDA.allowscalar(true)
+
 # The example is taken from the Trixi.jl
 
 ###############################################################################
@@ -29,8 +33,8 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                 periodicity = true)
 
 # create the semi discretization object
-semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
-                                    source_terms = source_terms_convergence_test)
+semi = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+                                       source_terms = source_terms_convergence_test)
 
 ###############################################################################
 # ODE solvers, callbacks etc.

--- a/src/TrixiCUDA.jl
+++ b/src/TrixiCUDA.jl
@@ -5,7 +5,7 @@ module TrixiCUDA
 
 using CUDA
 using CUDA: @cuda, CuArray, HostKernel,
-            threadIdx, blockIdx, blockDim, similar, launch_configuration
+            threadIdx, blockIdx, blockDim, reshape, similar, launch_configuration
 
 using Trixi: AbstractEquations, AbstractContainer, AbstractMesh, AbstractSemidiscretization,
              True, False, TreeMesh, DGSEM, SemidiscretizationHyperbolic,
@@ -24,7 +24,7 @@ using Trixi: AbstractEquations, AbstractContainer, AbstractMesh, AbstractSemidis
              set_log_type!, set_sqrt_type!
 
 import Trixi: get_node_vars, get_node_coords, get_surface_node_vars,
-              nelements, ninterfaces, nmortars
+              nelements, ninterfaces, nmortars, wrap_array
 
 using SciMLBase: ODEProblem, FullSpecialize
 

--- a/src/TrixiCUDA.jl
+++ b/src/TrixiCUDA.jl
@@ -15,16 +15,15 @@ using Trixi: AbstractEquations, AbstractContainer, AbstractMesh, AbstractSemidis
              LobattoLegendreMortarL2, L2MortarContainer2D, L2MortarContainer3D,
              BoundaryConditionPeriodic, BoundaryConditionDirichlet,
              VolumeIntegralWeakForm, VolumeIntegralFluxDifferencing, VolumeIntegralShockCapturingHG,
-             allocate_coefficients, mesh_equations_solver_cache,
+             allocate_coefficients, compute_coefficients, mesh_equations_solver_cache,
              flux, ntuple, nvariables, nnodes, nelements, nmortars,
              local_leaf_cells, init_elements, init_interfaces, init_boundaries, init_mortars,
-             wrap_array, compute_coefficients,
              have_nonconservative_terms, boundary_condition_periodic,
              digest_boundary_conditions, check_periodicity_mesh_boundary_conditions,
              set_log_type!, set_sqrt_type!
 
 import Trixi: get_node_vars, get_node_coords, get_surface_node_vars,
-              nelements, ninterfaces, nmortars, wrap_array
+              nelements, ninterfaces, nmortars, wrap_array, wrap_array_native
 
 using SciMLBase: ODEProblem, FullSpecialize
 

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -2,10 +2,15 @@
 # so here we adapt `wrap_array` to work with GPU arrays.
 function wrap_array(u_ode::CuArray, mesh::AbstractMesh, equations,
                     dg::DGSEM, cache)
-    return nothing
+    u_ode = reshape(u_ode, nvariables(equations), ntuple(_ -> nnodes(dg), ndims(mesh))...,
+                    nelements(dg, cache))
+
+    return u_ode
 end
 
 # Do we really have to compute the coefficients on the GPU?
+# Currently, these functions are disabled, please refer to function `semidiscretizeGPU`
+# for more details.
 ############################################################################## 
 # Kernel for computing the coefficients for 1D problems
 function compute_coefficients_kernel!(u, node_coordinates, func::Any, t,

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -1,3 +1,12 @@
+# The `wrap_array` function in Trixi.jl is not compatible with GPU arrays,
+# so here we adapt `wrap_array` to work with GPU arrays.
+function wrap_array(u_ode::CuArray, mesh::AbstractMesh, equations,
+                    dg::DGSEM, cache)
+    return nothing
+end
+
+# Do we really have to compute the coefficients on the GPU?
+############################################################################## 
 # Kernel for computing the coefficients for 1D problems
 function compute_coefficients_kernel!(u, node_coordinates, func::Any, t,
                                       equations::AbstractEquations{1})

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -1,16 +1,28 @@
 # The `wrap_array` function in Trixi.jl is not compatible with GPU arrays,
 # so here we adapt `wrap_array` to work with GPU arrays.
-function wrap_array(u_ode::CuArray, mesh::AbstractMesh, equations,
-                    dg::DGSEM, cache)
+@inline function wrap_array(u_ode::CuArray, mesh::AbstractMesh, equations,
+                            dg::DGSEM, cache)
+    # TODO: Assert array length before calling `reshape`
     u_ode = reshape(u_ode, nvariables(equations), ntuple(_ -> nnodes(dg), ndims(mesh))...,
                     nelements(dg, cache))
 
     return u_ode
 end
 
-# Do we really have to compute the coefficients on the GPU?
-# Currently, these functions are disabled, please refer to function `semidiscretizeGPU`
-# for more details.
+# The `wrap_array_native` function in Trixi.jl is not compatible with GPU arrays,
+# so here we adapt `wrap_array_native` to work with GPU arrays.
+@inline function wrap_array_native(u_ode::CuArray, mesh::AbstractMesh, equations,
+                                   dg::DGSEM, cache)
+    # TODO: Assert array length before calling `reshape`
+    u_ode = reshape(u_ode, nvariables(equations), ntuple(_ -> nnodes(dg), ndims(mesh))...,
+                    nelements(dg, cache))
+
+    return u_ode
+end
+
+# Do we really need to compute the coefficients on the GPU, and do we need to
+# initialize `du` and `u` with a 1D shape, as Trixi.jl does?
+# Note that the above questions also relate to whether using `wrap_array` and `wrap_array_native`.
 ############################################################################## 
 # Kernel for computing the coefficients for 1D problems
 function compute_coefficients_kernel!(u, node_coordinates, func::Any, t,

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -15,6 +15,7 @@ function rhs_gpu!(du_ode, u_ode, semi::SemidiscretizationHyperbolic, t)
     # In Trixi.jl, function `wrap_array` is called to adapt adaptive mesh refinement (AMR).
     # We are currently not considering AMR in TrixiCUDA.jl, so this step is not needed here. 
     # For more details, see https://trixi-framework.github.io/Trixi.jl/stable/conventions/#Array-types-and-wrapping
+
     # TODO: Adapt `wrap_array` on GPUs for AMR
     # u = wrap_array(u_ode, mesh, equations, solver, cache)
     # du = wrap_array(du_ode, mesh, equations, solver, cache)

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -25,14 +25,13 @@ end
 # See also `semidiscretize` function in Trixi.jl
 function semidiscretizeGPU(semi::SemidiscretizationHyperbolic, tspan)
     # Computing coefficients on GPUs may not be as fast as on CPUs due to the overhead. 
-    # Therefore, we currently use the CPU version. Note that the actual speedup on GPUs
+    # Therefore, we currently use the GPU version. Note that the actual speedup on GPUs
     # largely depends on the problem size (e.g., large arrays typically gain much more 
     # speedup than small arrays). 
 
-    # TODO: We may switch back to GPUs in the future if dealing with larger arrays
-    # u0_ode = compute_coefficients_gpu(first(tspan), semi)
-
-    u0_ode = CuArray(compute_coefficients(first(tspan), semi))
+    u0_ode = compute_coefficients_gpu(first(tspan), semi)
+    # TODO: We may switch back to CPUs in the future
+    # u0_ode = CuArray(compute_coefficients(first(tspan), semi))
 
     iip = true
     specialize = FullSpecialize

--- a/test/tree_dgsem_1d/advection_basic.jl
+++ b/test/tree_dgsem_1d/advection_basic.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/advection_extended.jl
+++ b/test/tree_dgsem_1d/advection_extended.jl
@@ -49,8 +49,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/burgers_basic.jl
+++ b/test/tree_dgsem_1d/burgers_basic.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/burgers_rarefraction.jl
+++ b/test/tree_dgsem_1d/burgers_rarefraction.jl
@@ -82,8 +82,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/burgers_shock.jl
+++ b/test/tree_dgsem_1d/burgers_shock.jl
@@ -83,8 +83,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/euler_blast_wave.jl
+++ b/test/tree_dgsem_1d/euler_blast_wave.jl
@@ -67,8 +67,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/euler_ec.jl
+++ b/test/tree_dgsem_1d/euler_ec.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/euler_shock.jl
+++ b/test/tree_dgsem_1d/euler_shock.jl
@@ -53,8 +53,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/euler_source_terms.jl
+++ b/test/tree_dgsem_1d/euler_source_terms.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
@@ -51,8 +51,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/eulermulti_ec.jl
+++ b/test/tree_dgsem_1d/eulermulti_ec.jl
@@ -50,8 +50,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/eulermulti_es.jl
+++ b/test/tree_dgsem_1d/eulermulti_es.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/eulerquasi_ec.jl
+++ b/test/tree_dgsem_1d/eulerquasi_ec.jl
@@ -54,8 +54,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/eulerquasi_source_terms.jl
+++ b/test/tree_dgsem_1d/eulerquasi_source_terms.jl
@@ -47,8 +47,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
@@ -63,8 +63,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
@@ -49,8 +49,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_1d/mhd_alfven_wave.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/mhd_ec.jl
+++ b/test/tree_dgsem_1d/mhd_ec.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_1d/shallowwater_shock.jl
+++ b/test/tree_dgsem_1d/shallowwater_shock.jl
@@ -86,8 +86,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/advection_basic.jl
+++ b/test/tree_dgsem_2d/advection_basic.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/advection_mortar.jl
+++ b/test/tree_dgsem_2d/advection_mortar.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/euler_blob_mortar.jl
+++ b/test/tree_dgsem_2d/euler_blob_mortar.jl
@@ -88,8 +88,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/euler_ec.jl
+++ b/test/tree_dgsem_2d/euler_ec.jl
@@ -47,8 +47,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -53,8 +53,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/euler_source_terms.jl
+++ b/test/tree_dgsem_2d/euler_source_terms.jl
@@ -43,8 +43,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
@@ -53,8 +53,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/eulermulti_ec.jl
+++ b/test/tree_dgsem_2d/eulermulti_ec.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/eulermulti_es.jl
+++ b/test/tree_dgsem_2d/eulermulti_es.jl
@@ -50,8 +50,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
@@ -52,8 +52,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave.jl
@@ -46,8 +46,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
@@ -50,8 +50,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/mhd_ec.jl
+++ b/test/tree_dgsem_2d/mhd_ec.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -56,8 +56,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/shallowwater_ec.jl
+++ b/test/tree_dgsem_2d/shallowwater_ec.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/shallowwater_source_terms.jl
+++ b/test/tree_dgsem_2d/shallowwater_source_terms.jl
@@ -48,8 +48,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
@@ -52,8 +52,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/advection_basic.jl
+++ b/test/tree_dgsem_3d/advection_basic.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/advection_mortar.jl
+++ b/test/tree_dgsem_3d/advection_mortar.jl
@@ -47,8 +47,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/euler_convergence.jl
+++ b/test/tree_dgsem_3d/euler_convergence.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/euler_ec.jl
+++ b/test/tree_dgsem_3d/euler_ec.jl
@@ -44,8 +44,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/euler_mortar.jl
+++ b/test/tree_dgsem_3d/euler_mortar.jl
@@ -46,8 +46,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -55,8 +55,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/euler_source_terms.jl
+++ b/test/tree_dgsem_3d/euler_source_terms.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
@@ -53,8 +53,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
@@ -49,8 +49,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/mhd_ec.jl
+++ b/test/tree_dgsem_3d/mhd_ec.jl
@@ -45,8 +45,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -56,8 +56,10 @@ include("../test_macros.jl")
 
     # ODE on GPU
     ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
-    u_gpu = copy(ode_gpu.u0)
-    du_gpu = similar(u_gpu)
+    u_gpu_ = copy(ode_gpu.u0)
+    du_gpu_ = similar(u_gpu_)
+    u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+    du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
 
     # Tests for components initialization
     @test_approx (u_gpu, u)


### PR DESCRIPTION
The original `wrap_array` function in Trixi.jl is not compatible with arrays on device. Here we adapt a new `wrap_array` specifically for GPU arrays. This PR should make most scripts under the example directory run successfully. 

EDIT: The original function `wrap_array_native` should also be adapted.