### PR TITLE
Fuse setting diagonal elements to zeros in `derivative_split` into kernels

### DIFF
--- a/src/solvers/common.jl
+++ b/src/solvers/common.jl
@@ -9,15 +9,6 @@
 #     return nothing
 # end
 
-# Set diagonal entries of a matrix to zeros
-function set_diagonal_to_zero!(A::Array)
-    n = min(size(A)...)
-    for i in 1:n
-        A[i, i] = zero(eltype(A))
-    end
-    return nothing
-end
-
 # Kernel for getting last and first indices
 # Maybe it is better to be moved to CPU
 function last_first_indices_kernel!(lasts, firsts, n_boundaries_per_direction)

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -40,7 +40,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr1, flux_arr2)
         j1 = div(j - 1, size(du, 2)) + 1
         j2 = rem(j - 1, size(du, 2)) + 1
 
-        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, k] += derivative_dhat[j1, ii] * flux_arr1[i, ii, j2, k] +
@@ -148,7 +148,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr1, volume_
         j1 = div(j - 1, size(du, 2)) + 1
         j2 = rem(j - 1, size(du, 2)) + 1
 
-        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, k] += derivative_split[j1, ii] * volume_flux_arr1[i, j1, ii, j2, k] +
@@ -273,7 +273,7 @@ function volume_integral_kernel!(du, derivative_split, symmetric_flux_arr1, symm
         j1 = div(j - 1, size(du, 2)) + 1
         j2 = rem(j - 1, size(du, 2)) + 1
 
-        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, k] += symmetric_flux_arr1[i, j1, ii, j2, k] +
@@ -449,7 +449,7 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
         j1 = div(j - 1, size(du, 2)) + 1
         j2 = rem(j - 1, size(du, 2)) + 1
 
-        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # initialize `du` with zeros
 
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero
@@ -581,7 +581,7 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
         j1 = div(j - 1, size(du, 2)) + 1
         j2 = rem(j - 1, size(du, 2)) + 1
 
-        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, k] = zero(eltype(du)) # initialize `du` with zeros
 
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -49,7 +49,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr1, flux_arr2, flux_arr3)
         j2 = div(rem(j - 1, u2^2), u2) + 1
         j3 = rem(rem(j - 1, u2^2), u2) + 1
 
-        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, j3, k] += derivative_dhat[j1, ii] * flux_arr1[i, ii, j2, j3, k] +
@@ -169,7 +169,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr1, volume_
         j2 = div(rem(j - 1, u2^2), u2) + 1
         j3 = rem(rem(j - 1, u2^2), u2) + 1
 
-        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, j3, k] += derivative_split[j1, ii] * volume_flux_arr1[i, j1, ii, j2, j3, k] +
@@ -310,7 +310,7 @@ function volume_integral_kernel!(du, derivative_split,
         j2 = div(rem(j - 1, u2^2), u2) + 1
         j3 = rem(rem(j - 1, u2^2), u2) + 1
 
-        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # initialize `du` with zeros
 
         for ii in axes(du, 2)
             @inbounds du[i, j1, j2, j3, k] += symmetric_flux_arr1[i, j1, ii, j2, j3, k] +
@@ -517,7 +517,7 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
         j2 = div(rem(j - 1, u2^2), u2) + 1
         j3 = rem(rem(j - 1, u2^2), u2) + 1
 
-        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # initialize `du` with zeros
 
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero
@@ -686,7 +686,7 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
         j2 = div(rem(j - 1, u2^2), u2) + 1
         j3 = rem(rem(j - 1, u2^2), u2) + 1
 
-        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # fuse `reset_du!` here
+        @inbounds du[i, j1, j2, j3, k] = zero(eltype(du)) # initialize `du` with zeros
 
         @inbounds begin
             element_dg = element_ids_dg[k] # check if `element_dg` is zero


### PR DESCRIPTION
The original process of setting diagonal elements in `derivative_split` is performed before launching the kernels, which is inefficient. Here, we fuse this process into the volume integral kernels using small tricks.

After the tests, the function `set_diagonal_to_zero!` should be removed.