### PR TITLE
Optimize volume integral kernels for shock capturing (less common use)

### DIFF
--- a/benchmark/advection_basic_1d.jl
+++ b/benchmark/advection_basic_1d.jl
@@ -10,6 +10,7 @@ advection_velocity = 1.0f0
 equations = LinearScalarAdvectionEquation1D(advection_velocity)
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
 
 coordinates_min = -1.0f0
 coordinates_max = 1.0f0
@@ -24,7 +25,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                                           solver)
 @info "Time for cache initialization on GPU"
 CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
-                                                      solver)
+                                                      solver_gpu)
 
 tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0

--- a/benchmark/advection_basic_2d.jl
+++ b/benchmark/advection_basic_2d.jl
@@ -10,6 +10,7 @@ advection_velocity = (0.2f0, -0.7f0)
 equations = LinearScalarAdvectionEquation2D(advection_velocity)
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
+solver = DGSEMGPU(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
 
 coordinates_min = (-1.0f0, -1.0f0)
 coordinates_max = (1.0f0, 1.0f0)
@@ -24,7 +25,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                                           solver)
 @info "Time for cache initialization on GPU"
 CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
-                                                      solver)
+                                                      solver_gpu)
 
 tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0

--- a/benchmark/advection_basic_3d.jl
+++ b/benchmark/advection_basic_3d.jl
@@ -10,6 +10,7 @@ advection_velocity = (0.2f0, -0.7f0, 0.5f0)
 equations = LinearScalarAdvectionEquation3D(advection_velocity)
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
 
 coordinates_min = (-1.0f0, -1.0f0, -1.0f0)
 coordinates_max = (1.0f0, 1.0f0, 1.0f0)
@@ -24,7 +25,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
                                           solver)
 @info "Time for cache initialization on GPU"
 CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition_convergence_test,
-                                                      solver)
+                                                      solver_gpu)
 
 tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0

--- a/benchmark/euler_ec_1d.jl
+++ b/benchmark/euler_ec_1d.jl
@@ -14,6 +14,9 @@ volume_flux = flux_ranocha
 solver = DGSEM(polydeg = 3, surface_flux = flux_ranocha,
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_ranocha,
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = (-2.0f0,)
 coordinates_max = (2.0f0,)
@@ -25,7 +28,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0

--- a/benchmark/euler_ec_2d.jl
+++ b/benchmark/euler_ec_2d.jl
@@ -14,6 +14,9 @@ volume_flux = flux_ranocha
 solver = DGSEM(polydeg = 3, surface_flux = flux_ranocha,
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_ranocha,
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = (-2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0)
@@ -27,7 +30,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                           boundary_conditions = boundary_condition_periodic)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu,
                                                       boundary_conditions = boundary_condition_periodic)
 
 tspan_gpu = (0.0f0, 0.4f0)

--- a/benchmark/euler_ec_3d.jl
+++ b/benchmark/euler_ec_3d.jl
@@ -14,6 +14,9 @@ volume_flux = flux_ranocha
 solver = DGSEM(polydeg = 2, surface_flux = flux_ranocha,
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 2, surface_flux = flux_ranocha,
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = (-2.0f0, -2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0, 2.0f0)
@@ -25,7 +28,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0

--- a/benchmark/euler_shock_1d.jl
+++ b/benchmark/euler_shock_1d.jl
@@ -12,7 +12,10 @@ initial_condition = initial_condition_weak_blast_wave
 
 surface_flux = flux_lax_friedrichs
 volume_flux = flux_shima_etal
+
 basis = LobattoLegendreBasis(RealT, 3)
+basis_gpu = LobattoLegendreBasisGPU(3, RealT)
+
 indicator_sc = IndicatorHennemannGassner(equations, basis,
                                          alpha_max = 0.5f0,
                                          alpha_min = 0.001f0,
@@ -21,7 +24,9 @@ indicator_sc = IndicatorHennemannGassner(equations, basis,
 volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                  volume_flux_dg = volume_flux,
                                                  volume_flux_fv = surface_flux)
+
 solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
 coordinates_min = -2.0f0
 coordinates_max = 2.0f0
@@ -33,7 +38,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan = tspan_gpu = (0.0f0, 0.4f0)
 t = t_gpu = 0.0f0
@@ -63,74 +68,7 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 
 # Reset du and volume integral
 @info "Time for reset_du! and volume_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                           Trixi.have_nonconservative_terms(equations_gpu),
-                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                           cache_gpu)
-@info "Time for reset_du! and volume_integral! on CPU"
-@time begin
-    Trixi.reset_du!(du, solver, cache)
-    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                equations, solver.volume_integral, solver, cache)
-end
-
-# Prolong to interfaces
-@info "Time for prolong2interfaces! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for prolong2interfaces! on CPU"
-@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Interface flux
-@info "Time for interface_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-                                          Trixi.have_nonconservative_terms(equations_gpu),
-                                          equations_gpu, solver_gpu, cache_gpu)
-@info "Time for interface_flux! on CPU"
-@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-                                 Trixi.have_nonconservative_terms(equations), equations,
-                                 solver.surface_integral, solver, cache)
-
-# Prolong to boundaries
-@info "Time for prolong2boundaries! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-                                              equations_gpu, cache_gpu)
-@info "Time for prolong2boundaries! on CPU"
-@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Boundary flux
-@info "Time for boundary_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-                                         Trixi.have_nonconservative_terms(equations_gpu),
-                                         equations_gpu, solver_gpu, cache_gpu)
-@info "Time for boundary_flux! on CPU"
-@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-                                solver.surface_integral, solver)
-
-# Surface integral
-@info "Time for surface_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-@info "Time for surface_integral! on CPU"
-@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-                                   solver, cache)
-
-# Jacobian
-@info "Time for jacobian! on GPU"
-CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for jacobian! on CPU"
-@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
-
-# Sources terms
-@info "Time for sources! on GPU"
-CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-                                   equations_gpu, cache_gpu)
-@info "Time for sources! on CPU"
-@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
-
-# Semidiscretization process
-@info "Time for rhs! on GPU"
-CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-                              boundary_conditions_gpu, source_terms_gpu,
-                              solver_gpu, cache_gpu)
-@info "Time for rhs! on CPU"
-@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-                 solver, cache)
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/euler_shock_2d.jl
+++ b/benchmark/euler_shock_2d.jl
@@ -12,7 +12,10 @@ initial_condition = initial_condition_weak_blast_wave
 
 surface_flux = flux_lax_friedrichs
 volume_flux = flux_shima_etal
+
 basis = LobattoLegendreBasis(RealT, 3)
+basis_gpu = LobattoLegendreBasisGPU(3, RealT)
+
 indicator_sc = IndicatorHennemannGassner(equations, basis,
                                          alpha_max = 0.5f0,
                                          alpha_min = 0.001f0,
@@ -21,7 +24,9 @@ indicator_sc = IndicatorHennemannGassner(equations, basis,
 volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                  volume_flux_dg = volume_flux,
                                                  volume_flux_fv = surface_flux)
+
 solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
 coordinates_min = (-2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0)
@@ -33,7 +38,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan = tspan_gpu = (0.0f0, 1.0f0)
 t = t_gpu = 0.0f0
@@ -63,93 +68,7 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 
 # Reset du and volume integral
 @info "Time for reset_du! and volume_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                           Trixi.have_nonconservative_terms(equations_gpu),
-                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                           cache_gpu)
-@info "Time for reset_du! and volume_integral! on CPU"
-@time begin
-    Trixi.reset_du!(du, solver, cache)
-    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                equations, solver.volume_integral, solver, cache)
-end
-
-# Prolong to interfaces
-@info "Time for prolong2interfaces! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for prolong2interfaces! on CPU"
-@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Interface flux
-@info "Time for interface_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-                                          Trixi.have_nonconservative_terms(equations_gpu),
-                                          equations_gpu, solver_gpu, cache_gpu)
-@info "Time for interface_flux! on CPU"
-@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-                                 Trixi.have_nonconservative_terms(equations), equations,
-                                 solver.surface_integral, solver, cache)
-
-# Prolong to boundaries
-@info "Time for prolong2boundaries! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-                                              equations_gpu, cache_gpu)
-@info "Time for prolong2boundaries! on CPU"
-@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Boundary flux
-@info "Time for boundary_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-                                         Trixi.have_nonconservative_terms(equations_gpu),
-                                         equations_gpu, solver_gpu, cache_gpu)
-@info "Time for boundary_flux! on CPU"
-@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-                                solver.surface_integral, solver)
-
-# Prolong to mortars
-@info "Time for prolong2mortars! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-                                           TrixiCUDA.check_cache_mortars(cache_gpu),
-                                           solver_gpu, cache_gpu)
-@info "Time for prolong2mortars! on CPU"
-@time Trixi.prolong2mortars!(cache, u, mesh, equations,
-                             solver.mortar, solver.surface_integral, solver)
-
-# Mortar flux
-@info "Time for mortar_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-                                       Trixi.have_nonconservative_terms(equations_gpu),
-                                       equations_gpu, solver_gpu, cache_gpu)
-@info "Time for mortar_flux! on CPU"
-@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-                              Trixi.have_nonconservative_terms(equations), equations,
-                              solver.mortar, solver.surface_integral, solver, cache)
-
-# Surface integral
-@info "Time for surface_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-@info "Time for surface_integral! on CPU"
-@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-                                   solver, cache)
-
-# Jacobian
-@info "Time for jacobian! on GPU"
-CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for jacobian! on CPU"
-@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
-
-# Sources terms
-@info "Time for sources! on GPU"
-CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-                                   equations_gpu, cache_gpu)
-@info "Time for sources! on CPU"
-@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
-
-# Semidiscretization process
-@info "Time for rhs! on GPU"
-CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-                              boundary_conditions_gpu, source_terms_gpu,
-                              solver_gpu, cache_gpu)
-@info "Time for rhs! on CPU"
-@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-                 solver, cache)
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/euler_shock_3d.jl
+++ b/benchmark/euler_shock_3d.jl
@@ -15,6 +15,8 @@ volume_flux = flux_ranocha
 
 polydeg = 3
 basis = LobattoLegendreBasis(RealT, polydeg)
+basis_gpu = LobattoLegendreBasisGPU(polydeg, RealT)
+
 indicator_sc = IndicatorHennemannGassner(equations, basis,
                                          alpha_max = 0.5f0,
                                          alpha_min = 0.001f0,
@@ -23,7 +25,9 @@ indicator_sc = IndicatorHennemannGassner(equations, basis,
 volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                  volume_flux_dg = volume_flux,
                                                  volume_flux_fv = surface_flux)
+
 solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
 coordinates_min = (-2.0f0, -2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0, 2.0f0)
@@ -36,7 +40,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
                                           source_terms = source_terms_convergence_test)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver,
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu,
                                                       source_terms = source_terms_convergence_test)
 
 tspan = tspan_gpu = (0.0f0, 0.4f0)
@@ -67,93 +71,7 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 
 # Reset du and volume integral
 @info "Time for reset_du! and volume_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
-                                           Trixi.have_nonconservative_terms(equations_gpu),
-                                           equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                           cache_gpu)
-@info "Time for reset_du! and volume_integral! on CPU"
-@time begin
-    Trixi.reset_du!(du, solver, cache)
-    Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
-                                equations, solver.volume_integral, solver, cache)
-end
-
-# Prolong to interfaces
-@info "Time for prolong2interfaces! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for prolong2interfaces! on CPU"
-@time Trixi.prolong2interfaces!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Interface flux
-@info "Time for interface_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_interface_flux!(mesh_gpu,
-                                          Trixi.have_nonconservative_terms(equations_gpu),
-                                          equations_gpu, solver_gpu, cache_gpu)
-@info "Time for interface_flux! on CPU"
-@time Trixi.calc_interface_flux!(cache.elements.surface_flux_values, mesh,
-                                 Trixi.have_nonconservative_terms(equations), equations,
-                                 solver.surface_integral, solver, cache)
-
-# Prolong to boundaries
-@info "Time for prolong2boundaries! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2boundaries!(u_gpu, mesh_gpu, boundary_conditions_gpu,
-                                              equations_gpu, cache_gpu)
-@info "Time for prolong2boundaries! on CPU"
-@time Trixi.prolong2boundaries!(cache, u, mesh, equations, solver.surface_integral, solver)
-
-# Boundary flux
-@info "Time for boundary_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_boundary_flux!(t_gpu, mesh_gpu, boundary_conditions_gpu,
-                                         Trixi.have_nonconservative_terms(equations_gpu),
-                                         equations_gpu, solver_gpu, cache_gpu)
-@info "Time for boundary_flux! on CPU"
-@time Trixi.calc_boundary_flux!(cache, t, boundary_conditions, mesh, equations,
-                                solver.surface_integral, solver)
-
-# Prolong to mortars
-@info "Time for prolong2mortars! on GPU"
-CUDA.@time TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
-                                           TrixiCUDA.check_cache_mortars(cache_gpu),
-                                           solver_gpu, cache_gpu)
-@info "Time for prolong2mortars! on CPU"
-@time Trixi.prolong2mortars!(cache, u, mesh, equations,
-                             solver.mortar, solver.surface_integral, solver)
-
-# Mortar flux
-@info "Time for mortar_flux! on GPU"
-CUDA.@time TrixiCUDA.cuda_mortar_flux!(mesh_gpu, TrixiCUDA.check_cache_mortars(cache_gpu),
-                                       Trixi.have_nonconservative_terms(equations_gpu),
-                                       equations_gpu, solver_gpu, cache_gpu)
-@info "Time for mortar_flux! on CPU"
-@time Trixi.calc_mortar_flux!(cache.elements.surface_flux_values, mesh,
-                              Trixi.have_nonconservative_terms(equations), equations,
-                              solver.mortar, solver.surface_integral, solver, cache)
-
-# Surface integral
-@info "Time for surface_integral! on GPU"
-CUDA.@time TrixiCUDA.cuda_surface_integral!(du_gpu, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
-@info "Time for surface_integral! on CPU"
-@time Trixi.calc_surface_integral!(du, u, mesh, equations, solver.surface_integral,
-                                   solver, cache)
-
-# Jacobian
-@info "Time for jacobian! on GPU"
-CUDA.@time TrixiCUDA.cuda_jacobian!(du_gpu, mesh_gpu, equations_gpu, cache_gpu)
-@info "Time for jacobian! on CPU"
-@time Trixi.apply_jacobian!(du, mesh, equations, solver, cache)
-
-# Sources terms
-@info "Time for sources! on GPU"
-CUDA.@time TrixiCUDA.cuda_sources!(du_gpu, u_gpu, t_gpu, source_terms_gpu,
-                                   equations_gpu, cache_gpu)
-@info "Time for sources! on CPU"
-@time Trixi.calc_sources!(du, u, t, source_terms, equations, solver, cache)
-
-# Semidiscretization process
-@info "Time for rhs! on GPU"
-CUDA.@time TrixiCUDA.rhs_gpu!(du_gpu, u_gpu, t_gpu, mesh_gpu, equations_gpu,
-                              boundary_conditions_gpu, source_terms_gpu,
-                              solver_gpu, cache_gpu)
-@info "Time for rhs! on CPU"
-@time Trixi.rhs!(du, u, t, mesh, equations, boundary_conditions, source_terms,
-                 solver, cache)
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/mhd_ec_1d.jl
+++ b/benchmark/mhd_ec_1d.jl
@@ -15,6 +15,9 @@ volume_flux = flux_hindenlang_gassner
 solver = DGSEM(polydeg = 3, surface_flux = flux_hindenlang_gassner,
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_hindenlang_gassner,
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = 0.0f0
 coordinates_max = 1.0f0
@@ -26,7 +29,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0

--- a/benchmark/mhd_ec_2d.jl
+++ b/benchmark/mhd_ec_2d.jl
@@ -15,6 +15,10 @@ solver = DGSEM(polydeg = 3,
                surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell),
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3,
+                      surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell),
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = (-2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0)
@@ -26,7 +30,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0

--- a/benchmark/mhd_ec_3d.jl
+++ b/benchmark/mhd_ec_3d.jl
@@ -15,6 +15,10 @@ solver = DGSEM(polydeg = 3,
                surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell),
                volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
                RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3,
+                      surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell),
+                      volume_integral = VolumeIntegralFluxDifferencing(volume_flux),
+                      RealT = RealT)
 
 coordinates_min = (-2.0f0, -2.0f0, -2.0f0)
 coordinates_max = (2.0f0, 2.0f0, 2.0f0)
@@ -26,7 +30,7 @@ mesh = TreeMesh(coordinates_min, coordinates_max,
 @info "Time for cache initialization on CPU"
 @time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
 @info "Time for cache initialization on GPU"
-CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver)
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
 
 tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0

--- a/benchmark/mhd_shock_2d.jl
+++ b/benchmark/mhd_shock_2d.jl
@@ -1,0 +1,8 @@
+using Trixi, TrixiCUDA
+using CUDA
+using BenchmarkTools
+
+# Set the precision
+RealT = Float32
+
+# Set up the problem

--- a/benchmark/mhd_shock_2d.jl
+++ b/benchmark/mhd_shock_2d.jl
@@ -6,3 +6,69 @@ using BenchmarkTools
 RealT = Float32
 
 # Set up the problem
+equations = IdealGlmMhdEquations2D(1.4f0)
+
+initial_condition = initial_condition_weak_blast_wave
+
+surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
+volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
+
+basis = LobattoLegendreBasis(RealT, 4)
+basis_gpu = LobattoLegendreBasisGPU(4, RealT)
+
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max = 0.5f0,
+                                         alpha_min = 0.001f0,
+                                         alpha_smooth = true,
+                                         variable = density_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
+
+coordinates_min = (-2.0f0, -2.0f0)
+coordinates_max = (2.0f0, 2.0f0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 3,
+                n_cells_max = 10_000, RealT = RealT)
+
+# Cache initialization
+@info "Time for cache initialization on CPU"
+@time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+@info "Time for cache initialization on GPU"
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
+
+tspan = tspan_gpu = (0.0f0, 1.0f0)
+t = t_gpu = 0.0f0
+
+# Semi on CPU
+(; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
+
+# Semi on GPU
+equations_gpu = semi_gpu.equations
+mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
+boundary_conditions_gpu = semi_gpu.boundary_conditions
+source_terms_gpu = semi_gpu.source_terms
+
+# ODE on CPU
+ode = semidiscretize(semi, tspan)
+u_ode = copy(ode.u0)
+du_ode = similar(u_ode)
+u = Trixi.wrap_array(u_ode, mesh, equations, solver, cache)
+du = Trixi.wrap_array(du_ode, mesh, equations, solver, cache)
+
+# ODE on GPU
+ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
+u_gpu_ = copy(ode_gpu.u0)
+du_gpu_ = similar(u_gpu_)
+u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/mhd_shock_3d.jl
+++ b/benchmark/mhd_shock_3d.jl
@@ -1,0 +1,8 @@
+using Trixi, TrixiCUDA
+using CUDA
+using BenchmarkTools
+
+# Set the precision
+RealT = Float32
+
+# Set up the problem

--- a/benchmark/mhd_shock_3d.jl
+++ b/benchmark/mhd_shock_3d.jl
@@ -6,3 +6,69 @@ using BenchmarkTools
 RealT = Float32
 
 # Set up the problem
+equations = IdealGlmMhdEquations3D(1.4f0)
+
+initial_condition = initial_condition_weak_blast_wave
+
+surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
+volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
+
+basis = LobattoLegendreBasis(RealT, 4)
+basis_gpu = LobattoLegendreBasisGPU(4, RealT)
+
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max = 0.5f0,
+                                         alpha_min = 0.001f0,
+                                         alpha_smooth = true,
+                                         variable = density_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
+
+coordinates_min = (-2.0f0, -2.0f0, -2.0f0)
+coordinates_max = (2.0f0, 2.0f0, 2.0f0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 3,
+                n_cells_max = 10_000, RealT = RealT)
+
+# Cache initialization
+@info "Time for cache initialization on CPU"
+@time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver)
+@info "Time for cache initialization on GPU"
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
+
+tspan = tspan_gpu = (0.0f0, 1.0f0)
+t = t_gpu = 0.0f0
+
+# Semi on CPU
+(; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
+
+# Semi on GPU
+equations_gpu = semi_gpu.equations
+mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
+boundary_conditions_gpu = semi_gpu.boundary_conditions
+source_terms_gpu = semi_gpu.source_terms
+
+# ODE on CPU
+ode = semidiscretize(semi, tspan)
+u_ode = copy(ode.u0)
+du_ode = similar(u_ode)
+u = Trixi.wrap_array(u_ode, mesh, equations, solver, cache)
+du = Trixi.wrap_array(du_ode, mesh, equations, solver, cache)
+
+# ODE on GPU
+ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
+u_gpu_ = copy(ode_gpu.u0)
+du_gpu_ = similar(u_gpu_)
+u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/shallowwater_shock_1d.jl
+++ b/benchmark/shallowwater_shock_1d.jl
@@ -6,3 +6,101 @@ using BenchmarkTools
 RealT = Float32
 
 # Set up the problem
+equations = ShallowWaterEquations1D(gravity_constant = 9.812f0, H0 = 1.75f0)
+
+function initial_condition_stone_throw_discontinuous_bottom(x, t,
+                                                            equations::ShallowWaterEquations1D)
+    # Flat lake
+    RealT = eltype(x)
+    H = equations.H0
+
+    # Discontinuous velocity
+    v = zero(RealT)
+    if x[1] >= -0.75f0 && x[1] <= 0
+        v = -one(RealT)
+    elseif x[1] >= 0 && x[1] <= 0.75f0
+        v = one(RealT)
+    end
+
+    b = (1.5f0 / exp(0.5f0 * ((x[1] - 1)^2)) +
+         0.75f0 / exp(0.5f0 * ((x[1] + 1)^2)))
+
+    # Force a discontinuous bottom topography
+    if x[1] >= -1.5f0 && x[1] <= 0
+        b = RealT(0.5f0)
+    end
+
+    return prim2cons(SVector(H, v, b), equations)
+end
+
+initial_condition = initial_condition_stone_throw_discontinuous_bottom
+
+boundary_condition = boundary_condition_slip_wall
+
+volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
+surface_flux = (FluxHydrostaticReconstruction(flux_lax_friedrichs,
+                                              hydrostatic_reconstruction_audusse_etal),
+                flux_nonconservative_audusse_etal)
+basis = LobattoLegendreBasis(RealT, 4)
+basis_gpu = LobattoLegendreBasisGPU(4, RealT)
+
+indicator_sc = IndicatorHennemannGassner(equations, basis,
+                                         alpha_max = 0.5f0,
+                                         alpha_min = 0.001f0,
+                                         alpha_smooth = true,
+                                         variable = waterheight_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver = DGSEM(basis, surface_flux, volume_integral)
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
+
+coordinates_min = -3.0f0
+coordinates_max = 3.0f0
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 3,
+                n_cells_max = 10_000,
+                periodicity = false,
+                RealT = RealT)
+
+# Cache initialization
+@info "Time for cache initialization on CPU"
+@time semi = SemidiscretizationHyperbolic(mesh, equations, initial_condition, solver,
+                                          boundary_conditions = boundary_condition)
+@info "Time for cache initialization on GPU"
+CUDA.@time semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu,
+                                                      boundary_conditions = boundary_condition)
+
+tspan = tspan_gpu = (0.0f0, 3.0f0)
+t = t_gpu = 0.0f0
+
+# Semi on CPU
+(; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
+
+# Semi on GPU
+equations_gpu = semi_gpu.equations
+mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
+boundary_conditions_gpu = semi_gpu.boundary_conditions
+source_terms_gpu = semi_gpu.source_terms
+
+# ODE on CPU
+ode = semidiscretize(semi, tspan)
+u_ode = copy(ode.u0)
+du_ode = similar(u_ode)
+u = Trixi.wrap_array(u_ode, mesh, equations, solver, cache)
+du = Trixi.wrap_array(du_ode, mesh, equations, solver, cache)
+
+# ODE on GPU
+ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
+u_gpu_ = copy(ode_gpu.u0)
+du_gpu_ = similar(u_gpu_)
+u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+
+# Reset du and volume integral
+@info "Time for reset_du! and volume_integral! on GPU"
+@benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                                      Trixi.have_nonconservative_terms(equations_gpu),
+                                                      equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                                      cache_gpu)

--- a/benchmark/shallowwater_shock_1d.jl
+++ b/benchmark/shallowwater_shock_1d.jl
@@ -1,0 +1,8 @@
+using Trixi, TrixiCUDA
+using CUDA
+using BenchmarkTools
+
+# Set the precision
+RealT = Float32
+
+# Set up the problem

--- a/src/solvers/common.jl
+++ b/src/solvers/common.jl
@@ -24,21 +24,3 @@ function last_first_indices_kernel!(lasts, firsts, n_boundaries_per_direction)
 
     return nothing
 end
-
-# Kernel for counting elements for DG-only and blended DG-FV volume integral
-# Maybe it is better to be moved to CPU
-function pure_blended_element_count_kernel!(element_ids_dg, element_ids_dgfv, alpha, atol)
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-
-    if (i <= length(alpha))
-        @inbounds dg_only = isapprox(alpha[i], 0, atol = atol)
-
-        if dg_only # bad
-            @inbounds element_ids_dg[i] = i
-        else
-            @inbounds element_ids_dgfv[i] = i
-        end
-    end
-
-    return nothing
-end

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -353,9 +353,10 @@ function volume_flux_dgfv_kernel!(volume_flux_arr, fstar1_L, fstar1_R, u,
     return nothing
 end
 
-# Kernel for calculating DG volume integral contribution
-function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
-                                    volume_flux_arr, equations::AbstractEquations{1})
+# Kernel for calculating pure DG and DG-FV volume integrals
+function volume_integral_dgfv_kernel!(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
+                                      inverse_weights, volume_flux_arr, fstar1_L, fstar1_R,
+                                      equations::AbstractEquations{1})
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
     k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
@@ -385,6 +386,9 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
                                                     (1 - isequal(j, ii)) * # set diagonal elements to zeros
                                                     volume_flux_arr[i, j, ii, element_dgfv]
             end
+
+            @inbounds du[i, j, element_dgfv] += alpha_element * inverse_weights[j] *
+                                                (fstar1_L[i, j + 1, element_dgfv] - fstar1_R[i, j, element_dgfv])
         end
     end
 
@@ -446,9 +450,10 @@ function volume_flux_dgfv_kernel!(volume_flux_arr, noncons_flux_arr, fstar1_L, f
     return nothing
 end
 
-# Kernel for calculating DG volume integral contribution
-function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
-                                    volume_flux_arr, noncons_flux_arr, equations::AbstractEquations{1})
+# Kernel for calculating pure DG and DG-FV volume integrals
+function volume_integral_dgfv_kernel!(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
+                                      inverse_weights, volume_flux_arr, noncons_flux_arr,
+                                      fstar1_L, fstar1_R, equations::AbstractEquations{1})
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
     k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
@@ -478,31 +483,9 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
                                                     0.5f0 * (1 - alpha_element) *
                                                     derivative_split[j, ii] * noncons_flux_arr[i, j, ii, element_dgfv]
             end
-        end
-    end
 
-    return nothing
-end
-
-# Kernel for calculating FV volume integral contribution 
-function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, inverse_weights, element_ids_dgfv,
-                                    alpha)
-    j = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    k = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-
-    if (j <= size(du, 2) && k <= size(du, 3))
-        # length(element_ids_dgfv) == size(du, 3)
-
-        @inbounds begin
-            element_dgfv = element_ids_dgfv[k] # check if `element_dgfv` is zero
-            alpha_element = alpha[k]
-        end
-
-        if element_dgfv != 0 # bad
-            for ii in axes(du, 1)
-                @inbounds du[ii, j, element_dgfv] += alpha_element * inverse_weights[j] *
-                                                     (fstar1_L[ii, j + 1, element_dgfv] - fstar1_R[ii, j, element_dgfv])
-            end
+            @inbounds du[i, j, element_dgfv] += alpha_element * inverse_weights[j] *
+                                                (fstar1_L[i, j + 1, element_dgfv] - fstar1_R[i, j, element_dgfv])
         end
     end
 
@@ -510,7 +493,7 @@ function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, inverse_weights, ele
 end
 
 ############################################################################## New optimization
-# Kernel for calculating DG-FV volume integrals without conservative terms
+# Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
 
 # Kernel for prolonging two interfaces
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids)
@@ -936,24 +919,16 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
                             kernel_configurator_2d(volume_flux_dgfv_kernel, size(u, 2)^2,
                                                    size(u, 3))...)
 
-    volume_integral_dg_kernel = @cuda launch=false volume_integral_dg_kernel!(du, element_ids_dg,
-                                                                              element_ids_dgfv,
-                                                                              alpha,
-                                                                              derivative_split,
-                                                                              volume_flux_arr,
-                                                                              equations)
-    volume_integral_dg_kernel(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
-                              volume_flux_arr, equations;
-                              kernel_configurator_3d(volume_integral_dg_kernel, size(du)...)...)
-
-    volume_integral_fv_kernel = @cuda launch=false volume_integral_fv_kernel!(du, fstar1_L,
-                                                                              fstar1_R,
-                                                                              inverse_weights,
-                                                                              element_ids_dgfv,
-                                                                              alpha)
-    volume_integral_fv_kernel(du, fstar1_L, fstar1_R, inverse_weights, element_ids_dgfv, alpha;
-                              kernel_configurator_2d(volume_integral_fv_kernel, size(u, 2),
-                                                     size(u, 3))...)
+    volume_integral_dgfv_kernel = @cuda launch=false volume_integral_dgfv_kernel!(du, element_ids_dg,
+                                                                                  element_ids_dgfv,
+                                                                                  alpha, derivative_split,
+                                                                                  inverse_weights,
+                                                                                  volume_flux_arr,
+                                                                                  fstar1_L, fstar1_R,
+                                                                                  equations)
+    volume_integral_dgfv_kernel(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split, inverse_weights,
+                                volume_flux_arr, fstar1_L, fstar1_R, equations;
+                                kernel_configurator_3d(volume_integral_dgfv_kernel, size(du)...)...)
 
     return nothing
 end
@@ -1009,25 +984,17 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
                             kernel_configurator_2d(volume_flux_dgfv_kernel, size(u, 2)^2,
                                                    size(u, 3))...)
 
-    volume_integral_dg_kernel = @cuda launch=false volume_integral_dg_kernel!(du, element_ids_dg,
-                                                                              element_ids_dgfv,
-                                                                              alpha,
-                                                                              derivative_split,
-                                                                              volume_flux_arr,
-                                                                              noncons_flux_arr,
-                                                                              equations)
-    volume_integral_dg_kernel(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split,
-                              volume_flux_arr, noncons_flux_arr, equations;
-                              kernel_configurator_3d(volume_integral_dg_kernel, size(du)...)...)
-
-    volume_integral_fv_kernel = @cuda launch=false volume_integral_fv_kernel!(du, fstar1_L,
-                                                                              fstar1_R,
-                                                                              inverse_weights,
-                                                                              element_ids_dgfv,
-                                                                              alpha)
-    volume_integral_fv_kernel(du, fstar1_L, fstar1_R, inverse_weights, element_ids_dgfv, alpha;
-                              kernel_configurator_2d(volume_integral_fv_kernel, size(u, 2),
-                                                     size(u, 3))...)
+    volume_integral_dgfv_kernel = @cuda launch=false volume_integral_dgfv_kernel!(du, element_ids_dg,
+                                                                                  element_ids_dgfv,
+                                                                                  alpha, derivative_split,
+                                                                                  inverse_weights,
+                                                                                  volume_flux_arr,
+                                                                                  noncons_flux_arr,
+                                                                                  fstar1_L, fstar1_R,
+                                                                                  equations)
+    volume_integral_dgfv_kernel(du, element_ids_dg, element_ids_dgfv, alpha, derivative_split, inverse_weights,
+                                volume_flux_arr, noncons_flux_arr, fstar1_L, fstar1_R, equations;
+                                kernel_configurator_3d(volume_integral_dgfv_kernel, size(du)...)...)
 
     return nothing
 end

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -39,7 +39,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr)
 end
 
 ############################################################################## New optimization
-# Kernel for calculating fluxes and weak form
+# Kernel for calculating volume integrals with weak form
 function flux_weak_form_kernel!(du, u, derivative_dhat,
                                 equations::AbstractEquations{1}, flux::Any)
     # Set tile width
@@ -129,7 +129,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr,
 end
 
 ############################################################################## New optimization
-# Kernel for calculating volume fluxes and volume integrals
+# Kernel for calculating volume integrals without conservative terms
 function volume_flux_integral_kernel!(du, u, derivative_split,
                                       equations::AbstractEquations{1}, volume_flux::Any)
     # Set tile width
@@ -237,8 +237,7 @@ function volume_integral_kernel!(du, derivative_split, symmetric_flux_arr, nonco
 end
 
 ############################################################################## New optimization
-# Kernel for calculating symmetric and nonconservative volume fluxes and 
-# corresponding volume integrals
+# Kernel for calculating volume integrals with conservative terms
 function noncons_volume_flux_integral_kernel!(du, u, derivative_split,
                                               equations::AbstractEquations{1},
                                               symmetric_flux::Any, nonconservative_flux::Any)
@@ -509,6 +508,9 @@ function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, inverse_weights, ele
 
     return nothing
 end
+
+############################################################################## New optimization
+# Kernel for calculating DG-FV volume integrals without conservative terms
 
 # Kernel for prolonging two interfaces
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids)

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -469,8 +469,8 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
                 @inbounds begin
                     du[i, j1, j2, element_dg] += derivative_split[j1, ii] *
                                                  (1 - isequal(j1, ii)) * # set diagonal elements to zeros
-                                                 volume_flux_arr1[i, j1, ii, j2, element_dg]
-                    du[i, j1, j2, element_dg] += derivative_split[j2, ii] *
+                                                 volume_flux_arr1[i, j1, ii, j2, element_dg] +
+                                                 derivative_split[j2, ii] *
                                                  (1 - isequal(j2, ii)) * # set diagonal elements to zeros
                                                  volume_flux_arr2[i, j1, j2, ii, element_dg]
                 end
@@ -482,8 +482,8 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
                 @inbounds begin
                     du[i, j1, j2, element_dgfv] += (1 - alpha_element) * derivative_split[j1, ii] *
                                                    (1 - isequal(j1, ii)) * # set diagonal elements to zeros
-                                                   volume_flux_arr1[i, j1, ii, j2, element_dgfv]
-                    du[i, j1, j2, element_dgfv] += (1 - alpha_element) * derivative_split[j2, ii] *
+                                                   volume_flux_arr1[i, j1, ii, j2, element_dgfv] +
+                                                   (1 - alpha_element) * derivative_split[j2, ii] *
                                                    (1 - isequal(j2, ii)) * # set diagonal elements to zeros
                                                    volume_flux_arr2[i, j1, j2, ii, element_dgfv]
                 end
@@ -601,41 +601,25 @@ function volume_integral_dg_kernel!(du, element_ids_dg, element_ids_dgfv, alpha,
         end
 
         if element_dg != 0 # bad
-            integral_contribution = zero(eltype(du))
-
             for ii in axes(du, 2)
-                @inbounds begin
-                    du[i, j1, j2, element_dg] += volume_flux_arr1[i, j1, ii, j2, element_dg]
-                    du[i, j1, j2, element_dg] += volume_flux_arr2[i, j1, j2, ii, element_dg]
-
-                    integral_contribution += derivative_split[j1, ii] *
-                                             noncons_flux_arr1[i, j1, ii, j2, element_dg]
-                    integral_contribution += derivative_split[j2, ii] *
-                                             noncons_flux_arr2[i, j1, j2, ii, element_dg]
-                end
+                @inbounds du[i, j1, j2, element_dg] += volume_flux_arr1[i, j1, ii, j2, element_dg] +
+                                                       volume_flux_arr2[i, j1, j2, ii, element_dg] +
+                                                       0.5f0 *
+                                                       (derivative_split[j1, ii] * noncons_flux_arr1[i, j1, ii, j2, element_dg] +
+                                                        derivative_split[j2, ii] * noncons_flux_arr2[i, j1, j2, ii, element_dg])
             end
-
-            @inbounds du[i, j1, j2, element_dg] += 0.5f0 * integral_contribution
         end
 
         if element_dgfv != 0 # bad
-            integral_contribution = zero(eltype(du))
-
             for ii in axes(du, 2)
-                @inbounds begin
-                    du[i, j1, j2, element_dgfv] += (1 - alpha_element) *
-                                                   volume_flux_arr1[i, j1, ii, j2, element_dgfv]
-                    du[i, j1, j2, element_dgfv] += (1 - alpha_element) *
-                                                   volume_flux_arr2[i, j1, j2, ii, element_dgfv]
-
-                    integral_contribution += derivative_split[j1, ii] *
-                                             noncons_flux_arr1[i, j1, ii, j2, element_dgfv]
-                    integral_contribution += derivative_split[j2, ii] *
-                                             noncons_flux_arr2[i, j1, j2, ii, element_dgfv]
-                end
+                @inbounds du[i, j1, j2, element_dgfv] += (1 - alpha_element) *
+                                                         volume_flux_arr1[i, j1, ii, j2, element_dgfv] +
+                                                         (1 - alpha_element) *
+                                                         volume_flux_arr2[i, j1, j2, ii, element_dgfv] +
+                                                         0.5f0 * (1 - alpha_element) *
+                                                         (derivative_split[j1, ii] * noncons_flux_arr1[i, j1, ii, j2, element_dgfv] +
+                                                          derivative_split[j2, ii] * noncons_flux_arr2[i, j1, j2, ii, element_dgfv])
             end
-
-            @inbounds du[i, j1, j2, element_dgfv] += 0.5f0 * (1 - alpha_element) * integral_contribution
         end
     end
 
@@ -661,12 +645,11 @@ function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, fstar2_L, fstar2_R,
 
         if element_dgfv != 0 # bad
             for ii in axes(du, 1)
-                @inbounds du[ii, j1, j2, element_dgfv] += alpha_element * ((inverse_weights[j1] *
-                                                            (fstar1_L[ii, j1 + 1, j2, element_dgfv] -
-                                                             fstar1_R[ii, j1, j2, element_dgfv]) +
-                                                            inverse_weights[j2] *
-                                                            (fstar2_L[ii, j1, j2 + 1, element_dgfv] -
-                                                             fstar2_R[ii, j1, j2, element_dgfv])))
+                @inbounds du[ii, j1, j2, element_dgfv] += alpha_element *
+                                                          (inverse_weights[j1] *
+                                                           (fstar1_L[ii, j1 + 1, j2, element_dgfv] - fstar1_R[ii, j1, j2, element_dgfv]) +
+                                                           inverse_weights[j2] *
+                                                           (fstar2_L[ii, j1, j2 + 1, element_dgfv] - fstar2_R[ii, j1, j2, element_dgfv]))
             end
         end
     end

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -52,7 +52,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr1, flux_arr2)
 end
 
 ############################################################################## New optimization
-# Kernel for calculating fluxes and weak form
+# Kernel for calculating volume integrals with weak form
 function flux_weak_form_kernel!(du, u, derivative_dhat,
                                 equations::AbstractEquations{2}, flux::Any)
     # Set tile width
@@ -162,7 +162,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr1, volume_
 end
 
 ############################################################################## New optimization
-# Kernel for calculating volume fluxes and volume integrals
+# Kernel for calculating volume integrals without conservative terms
 function volume_flux_integral_kernel!(du, u, derivative_split,
                                       equations::AbstractEquations{2}, volume_flux::Any)
     # Set tile width
@@ -295,8 +295,7 @@ function volume_integral_kernel!(du, derivative_split, symmetric_flux_arr1, symm
 end
 
 ############################################################################## New optimization
-# Kernel for calculating symmetric and nonconservative volume fluxes and 
-# corresponding volume integrals
+# Kernel for calculating volume integrals with conservative terms
 function noncons_volume_flux_integral_kernel!(du, u, derivative_split,
                                               equations::AbstractEquations{2},
                                               symmetric_flux::Any, nonconservative_flux::Any)
@@ -656,6 +655,9 @@ function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, fstar2_L, fstar2_R,
 
     return nothing
 end
+
+############################################################################## New optimization
+# Kernel for calculating DG-FV volume integrals without conservative terms
 
 # Kernel for prolonging two interfaces 
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids, orientations,

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -62,7 +62,7 @@ function weak_form_kernel!(du, derivative_dhat, flux_arr1, flux_arr2, flux_arr3)
 end
 
 ############################################################################## New optimization
-# Kernel for calculating fluxes and weak form
+# Kernel for calculating volume integrals with weak form
 function flux_weak_form_kernel!(du, u, derivative_dhat,
                                 equations::AbstractEquations{3}, flux::Any)
     # Set tile width
@@ -185,7 +185,7 @@ function volume_integral_kernel!(du, derivative_split, volume_flux_arr1, volume_
 end
 
 ############################################################################## New optimization
-# Kernel for calculating volume fluxes and volume integrals
+# Kernel for calculating volume integrals without conservative terms
 function volume_flux_integral_kernel!(du, u, derivative_split,
                                       equations::AbstractEquations{3}, volume_flux::Any)
     # Set tile width
@@ -337,8 +337,7 @@ function volume_integral_kernel!(du, derivative_split,
 end
 
 ############################################################################## New optimization
-# Kernel for calculating symmetric and nonconservative volume fluxes and 
-# corresponding volume integrals
+# Kernel for calculating volume integrals with conservative terms
 function noncons_volume_flux_integral_kernel!(du, u, derivative_split,
                                               equations::AbstractEquations{3},
                                               symmetric_flux::Any, nonconservative_flux::Any)
@@ -768,6 +767,9 @@ function volume_integral_fv_kernel!(du, fstar1_L, fstar1_R, fstar2_L, fstar2_R,
 
     return nothing
 end
+
+############################################################################## New optimization
+# Kernel for calculating DG-FV volume integrals without conservative terms
 
 # Kernel for prolonging two interfaces
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids, orientations,

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -12,9 +12,10 @@ include("../test_macros.jl")
 
     surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
     volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
-    polydeg = 4
-    basis = LobattoLegendreBasis(polydeg)
-    basis_gpu = LobattoLegendreBasisGPU(polydeg)
+
+    basis = LobattoLegendreBasis(4)
+    basis_gpu = LobattoLegendreBasisGPU(4)
+
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,
                                              alpha_min = 0.001,
@@ -24,10 +25,8 @@ include("../test_macros.jl")
                                                      volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
 
-    solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux,
-                   volume_integral = volume_integral)
-    solver_gpu = DGSEMGPU(polydeg = polydeg, surface_flux = surface_flux,
-                          volume_integral = volume_integral)
+    solver = DGSEM(basis, surface_flux, volume_integral)
+    solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
     coordinates_min = (-2.0, -2.0)
     coordinates_max = (2.0, 2.0)

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -12,9 +12,10 @@ include("../test_macros.jl")
 
     surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
     volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
-    polydeg = 4
-    basis = LobattoLegendreBasis(polydeg)
-    basis_gpu = LobattoLegendreBasisGPU(polydeg)
+
+    basis = LobattoLegendreBasis(4)
+    basis_gpu = LobattoLegendreBasisGPU(4)
+
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,
                                              alpha_min = 0.001,
@@ -24,10 +25,8 @@ include("../test_macros.jl")
                                                      volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
 
-    solver = DGSEM(polydeg = polydeg, surface_flux = surface_flux,
-                   volume_integral = volume_integral)
-    solver_gpu = DGSEMGPU(polydeg = polydeg, surface_flux = surface_flux,
-                          volume_integral = volume_integral)
+    solver = DGSEM(basis, surface_flux, volume_integral)
+    solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
     coordinates_min = (-2.0, -2.0, -2.0)
     coordinates_max = (2.0, 2.0, 2.0)


### PR DESCRIPTION
The original volume integral kernels for shock capturing is not good in performance. This PR will optimize them.

The possible tasks include:

- [x] Optimize directly on the original kernels (larger size, less common use)
- [x] Tests the above kernels

EDIT: This will also address #74.