### PR TITLE
Optimize volume integral kernels for shock capturing (frequent use)

### DIFF
--- a/profile/profiling_kernel2.jl
+++ b/profile/profiling_kernel2.jl
@@ -1,0 +1,56 @@
+using Trixi, TrixiCUDA
+using CUDA
+
+# Set the precision
+RealT = Float32
+
+# Set up the problem
+equations = CompressibleEulerEquations2D(1.4f0)
+
+initial_condition = initial_condition_weak_blast_wave
+
+surface_flux = flux_lax_friedrichs
+volume_flux = flux_shima_etal
+
+basis_gpu = LobattoLegendreBasisGPU(3, RealT)
+
+indicator_sc = IndicatorHennemannGassner(equations, basis_gpu,
+                                         alpha_max = 0.5f0,
+                                         alpha_min = 0.001f0,
+                                         alpha_smooth = true,
+                                         variable = density_pressure)
+volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
+                                                 volume_flux_dg = volume_flux,
+                                                 volume_flux_fv = surface_flux)
+
+solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
+
+coordinates_min = (-2.0f0, -2.0f0)
+coordinates_max = (2.0f0, 2.0f0)
+mesh = TreeMesh(coordinates_min, coordinates_max,
+                initial_refinement_level = 5,
+                n_cells_max = 10_000, RealT = RealT)
+
+semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
+
+tspan_gpu = (0.0f0, 1.0f0)
+t_gpu = 0.0f0
+
+# Semi on GPU
+equations_gpu = semi_gpu.equations
+mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
+boundary_conditions_gpu = semi_gpu.boundary_conditions
+source_terms_gpu = semi_gpu.source_terms
+
+# ODE on GPU
+ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
+u_gpu_ = copy(ode_gpu.u0)
+du_gpu_ = similar(u_gpu_)
+u_gpu = TrixiCUDA.wrap_array(u_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cache_gpu)
+
+# Reset du and volume integral
+TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
+                                Trixi.have_nonconservative_terms(equations_gpu),
+                                equations_gpu, solver_gpu.volume_integral, solver_gpu,
+                                cache_gpu)

--- a/profile/profiling_kernel3.jl
+++ b/profile/profiling_kernel3.jl
@@ -4,14 +4,15 @@ using Trixi, TrixiCUDA
 RealT = Float32
 
 # Set up the problem
-equations = CompressibleEulerEquations2D(1.4f0)
+equations = CompressibleEulerEquations3D(1.4f0)
 
 initial_condition = initial_condition_weak_blast_wave
 
-surface_flux = flux_lax_friedrichs
-volume_flux = flux_shima_etal
+surface_flux = flux_ranocha
+volume_flux = flux_ranocha
 
-basis_gpu = LobattoLegendreBasisGPU(3, RealT)
+polydeg = 3
+basis_gpu = LobattoLegendreBasisGPU(polydeg, RealT)
 
 indicator_sc = IndicatorHennemannGassner(equations, basis_gpu,
                                          alpha_max = 0.5f0,
@@ -24,15 +25,16 @@ volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
 
 solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 
-coordinates_min = (-2.0f0, -2.0f0)
-coordinates_max = (2.0f0, 2.0f0)
+coordinates_min = (-2.0f0, -2.0f0, -2.0f0)
+coordinates_max = (2.0f0, 2.0f0, 2.0f0)
 mesh = TreeMesh(coordinates_min, coordinates_max,
-                initial_refinement_level = 5,
-                n_cells_max = 10_000, RealT = RealT)
+                initial_refinement_level = 3,
+                n_cells_max = 100_000, RealT = RealT)
 
-semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu)
+semi_gpu = SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver_gpu,
+                                           source_terms = source_terms_convergence_test)
 
-tspan_gpu = (0.0f0, 1.0f0)
+tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -267,6 +267,7 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     # Load data from global memory into shared memory
     for ty2 in axes(du, 2)
         # Transposed access
+        # TODO: Combine into single shared memory
         @inbounds begin
             shmem_split[ty2, ty] = derivative_split[ty, ty2]
             shmem_szero[ty2, ty] = derivative_split[ty, ty2] *
@@ -392,7 +393,17 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
-function volume_flux_integral_dgfv_kernel!()
+function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split, inverse_weights,
+                                           equations::AbstractEquations{1},
+                                           volume_flux_dg::Any, volume_flux_fv::Any)
+    # Set tile width
+    tile_width = size(du, 2)
+    offset = 0 # offset bytes for shared memory
+
+    # Allocate dynamic shared memory
+    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    offset += sizeof(eltype(du)) * tile_width^2
+
     return nothing
 end
 

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -238,9 +238,9 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating volume integrals with conservative terms
-function noncons_volume_flux_integral_kernel!(du, u, derivative_split,
-                                              equations::AbstractEquations{1},
-                                              symmetric_flux::Any, nonconservative_flux::Any)
+function volume_flux_integral_kernel!(du, u, derivative_split,
+                                      equations::AbstractEquations{1},
+                                      symmetric_flux::Any, nonconservative_flux::Any)
     # Set tile width
     tile_width = size(du, 2)
     offset = 0 # offset bytes for shared memory
@@ -390,6 +390,12 @@ function volume_integral_dgfv_kernel!(du, alpha, derivative_split, inverse_weigh
     return nothing
 end
 
+############################################################################## New optimization
+# Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
+function volume_flux_integral_dgfv_kernel!()
+    return nothing
+end
+
 # Kernel for calculating pure DG and DG-FV volume fluxes
 function volume_flux_dgfv_kernel!(volume_flux_arr, noncons_flux_arr, fstar1_L, fstar1_R, u,
                                   alpha, atol, derivative_split,
@@ -485,7 +491,7 @@ function volume_integral_dgfv_kernel!(du, alpha, derivative_split, inverse_weigh
 end
 
 ############################################################################## New optimization
-# Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
+# Kernel for calculating pure DG and DG-FV volume integrals with conservative terms
 
 # Kernel for prolonging two interfaces
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids)
@@ -857,11 +863,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
         shmem_size = (size(du, 2)^2 * 2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
         threads = (1, size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size noncons_volume_flux_integral_kernel!(du, u,
-                                                                                                  derivative_split,
-                                                                                                  equations,
-                                                                                                  symmetric_flux,
-                                                                                                  nonconservative_flux)
+        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
+                                                                                          derivative_split,
+                                                                                          equations,
+                                                                                          symmetric_flux,
+                                                                                          nonconservative_flux)
     end
 
     return nothing

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -61,7 +61,8 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
 
     # Load global `derivative_dhat` into shared memory
     for ty2 in axes(du, 2)
-        @inbounds shmem_dhat[ty2, ty] = derivative_dhat[ty, ty2] # transposed access
+        # Transposed access
+        @inbounds shmem_dhat[ty2, ty] = derivative_dhat[ty, ty2]
     end
 
     # Compute flux values

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -512,6 +512,7 @@ function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
+    # TODO: Combine `fstar` into single allocation
     shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
     shmem_fstar1 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width + 1, tile_width),
@@ -566,7 +567,6 @@ function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split,
             # Set with FV volume fluxes
             @inbounds shmem_fstar1[tx, ty1 + 1, ty2] = flux_fv_node1[tx] * (1 - dg_only)
         end
-
         if ty2 + 1 <= tile_width
             # Set with FV volume fluxes
             @inbounds shmem_fstar2[tx, ty1, ty2 + 1] = flux_fv_node2[tx] * (1 - dg_only)

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -326,6 +326,7 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
 
     # Load data from global memory into shared memory
     # Transposed access
+    # TODO: Combine into single shared memory
     @inbounds begin
         shmem_split[ty2, ty1] = derivative_split[ty1, ty2]
         shmem_szero[ty2, ty1] = derivative_split[ty1, ty2] *

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -504,9 +504,9 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
-function volume_flux_integral_dgfv_kernel!()
-    return nothing
-end
+# function volume_flux_integral_dgfv_kernel!()
+#     return nothing
+# end
 
 # Kernel for calculating pure DG and DG-FV volume fluxes
 function volume_flux_dgfv_kernel!(volume_flux_arr1, volume_flux_arr2, noncons_flux_arr1,

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -296,9 +296,9 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating volume integrals with conservative terms
-function noncons_volume_flux_integral_kernel!(du, u, derivative_split,
-                                              equations::AbstractEquations{2},
-                                              symmetric_flux::Any, nonconservative_flux::Any)
+function volume_flux_integral_kernel!(du, u, derivative_split,
+                                      equations::AbstractEquations{2},
+                                      symmetric_flux::Any, nonconservative_flux::Any)
     # Set tile width
     tile_width = size(du, 2)
     offset = 0 # offset bytes for shared memory
@@ -500,6 +500,12 @@ function volume_integral_dgfv_kernel!(du, alpha, derivative_split, inverse_weigh
     return nothing
 end
 
+############################################################################## New optimization
+# Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
+function volume_flux_integral_dgfv_kernel!()
+    return nothing
+end
+
 # Kernel for calculating pure DG and DG-FV volume fluxes
 function volume_flux_dgfv_kernel!(volume_flux_arr1, volume_flux_arr2, noncons_flux_arr1,
                                   noncons_flux_arr2, fstar1_L, fstar1_R, fstar2_L, fstar2_R,
@@ -648,7 +654,7 @@ function volume_integral_dgfv_kernel!(du, alpha, derivative_split, inverse_weigh
 end
 
 ############################################################################## New optimization
-# Kernel for calculating DG-FV volume integrals without conservative terms
+# Kernel for calculating pure DG and DG-FV volume integrals with conservative terms
 
 # Kernel for prolonging two interfaces 
 function prolong_interfaces_kernel!(interfaces_u, u, neighbor_ids, orientations,
@@ -1348,11 +1354,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
         shmem_size = (size(du, 2)^2 * 2 + size(du, 1) * size(du, 2)^2) * sizeof(RealT)
         threads = (1, size(du, 2)^2, 1)
         blocks = (1, 1, size(du, 4))
-        @cuda threads=threads blocks=blocks shmem=shmem_size noncons_volume_flux_integral_kernel!(du, u,
-                                                                                                  derivative_split,
-                                                                                                  equations,
-                                                                                                  symmetric_flux,
-                                                                                                  nonconservative_flux)
+        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
+                                                                                          derivative_split,
+                                                                                          equations,
+                                                                                          symmetric_flux,
+                                                                                          nonconservative_flux)
     end
 
     return nothing

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -76,7 +76,8 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
     value = zero(eltype(du))
 
     # Load global `derivative_dhat` into shared memory
-    @inbounds shmem_dhat[ty2, ty1] = derivative_dhat[ty1, ty2] # transposed access
+    # Transposed access
+    @inbounds shmem_dhat[ty2, ty1] = derivative_dhat[ty1, ty2]
 
     # Compute flux values
     u_node = get_node_vars(u, equations, ty1, ty2, k)

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -87,7 +87,8 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
     value = zero(eltype(du))
 
     # Load global `derivative_dhat` into shared memory
-    @inbounds shmem_dhat[ty2, ty1] = derivative_dhat[ty1, ty2] # transposed access
+    # Transposed access
+    @inbounds shmem_dhat[ty2, ty1] = derivative_dhat[ty1, ty2]
 
     # Compute flux values
     u_node = get_node_vars(u, equations, ty1, ty2, ty3, k)

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -593,9 +593,11 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
-# function volume_flux_integral_dgfv_kernel!()
-#     return nothing
-# end
+function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split, inverse_weights,
+                                           equations::AbstractEquations{3},
+                                           volume_flux_dg::Any, volume_flux_fv::Any)
+    return nothing
+end
 
 # Kernel for calculating pure DG and DG-FV volume fluxes
 function volume_flux_dgfv_kernel!(volume_flux_arr1, volume_flux_arr2, volume_flux_arr3,

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -593,9 +593,9 @@ end
 
 ############################################################################## New optimization
 # Kernel for calculating pure DG and DG-FV volume integrals without conservative terms
-function volume_flux_integral_dgfv_kernel!()
-    return nothing
-end
+# function volume_flux_integral_dgfv_kernel!()
+#     return nothing
+# end
 
 # Kernel for calculating pure DG and DG-FV volume fluxes
 function volume_flux_dgfv_kernel!(volume_flux_arr1, volume_flux_arr2, volume_flux_arr3,

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -596,6 +596,141 @@ end
 function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split, inverse_weights,
                                            equations::AbstractEquations{3},
                                            volume_flux_dg::Any, volume_flux_fv::Any)
+    # Set tile width
+    tile_width = size(du, 2)
+    offset = 0 # offset bytes for shared memory
+
+    # Allocate dynamic shared memory
+    # TODO: Combine `fstar` into single allocation
+    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    offset += sizeof(eltype(du)) * tile_width^2
+    shmem_fstar1 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width + 1, tile_width, tile_width),
+                                       offset)
+    offset += sizeof(eltype(du)) * size(du, 1) * (tile_width + 1) * tile_width * tile_width
+    shmem_fstar2 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width + 1, tile_width),
+                                       offset)
+    offset += sizeof(eltype(du)) * size(du, 1) * tile_width * (tile_width + 1) * tile_width
+    shmem_fstar3 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width + 1),
+                                       offset)
+    offset += sizeof(eltype(du)) * size(du, 1) * tile_width * tile_width * (tile_width + 1)
+    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
+                                      offset)
+
+    # Get thread and block indices only we need save registers
+    ty = threadIdx().y
+    k = (blockIdx().z - 1) * blockDim().z + threadIdx().z
+    ty1 = div(ty - 1, tile_width^2) + 1
+    ty2 = div(rem(ty - 1, tile_width^2), tile_width) + 1
+    ty3 = rem(rem(ty - 1, tile_width^2), tile_width) + 1
+
+    # Load global `derivative_split` into shared memory
+    # Transposed access
+    @inbounds shmem_split[ty2, ty1] = derivative_split[ty1, ty2]
+
+    # Get variables for computation
+    @inbounds alpha_element = alpha[k]
+    dg_only = isapprox(alpha_element, 0, atol = atol)
+
+    # Compute FV volume fluxes
+    u_node = get_node_vars(u, equations, ty1, ty2, ty3, k)
+    if ty1 + 1 <= tile_width
+        flux_fv_node1 = volume_flux_fv(u_node,
+                                       get_node_vars(u, equations, ty1 + 1, ty2, ty3, k),
+                                       1, equations)
+    end
+    if ty2 + 1 <= tile_width
+        flux_fv_node2 = volume_flux_fv(u_node,
+                                       get_node_vars(u, equations, ty1, ty2 + 1, ty3, k),
+                                       2, equations)
+    end
+    if ty3 + 1 <= tile_width
+        flux_fv_node3 = volume_flux_fv(u_node,
+                                       get_node_vars(u, equations, ty1, ty2, ty3 + 1, k),
+                                       3, equations)
+    end
+
+    # Initialize the values
+    for tx in axes(du, 1)
+        @inbounds begin
+            # Initialize `du` with zeros
+            shmem_value[tx, ty1, ty2, ty3] = zero(eltype(du))
+            # Initialize `fstar` side columes with zeros 
+            shmem_fstar1[tx, 1, ty2, ty3] = zero(eltype(du))
+            shmem_fstar1[tx, tile_width + 1, ty2, ty3] = zero(eltype(du))
+            shmem_fstar2[tx, ty1, 1, ty3] = zero(eltype(du))
+            shmem_fstar2[tx, ty1, tile_width + 1, ty3] = zero(eltype(du))
+            shmem_fstar3[tx, ty1, ty2, 1] = zero(eltype(du))
+            shmem_fstar3[tx, ty1, ty2, tile_width + 1] = zero(eltype(du))
+        end
+
+        if ty1 + 1 <= tile_width
+            # Set with FV volume fluxes
+            @inbounds shmem_fstar1[tx, ty1 + 1, ty2, ty3] = flux_fv_node1[tx] * (1 - dg_only)
+        end
+        if ty2 + 1 <= tile_width
+            # Set with FV volume fluxes
+            @inbounds shmem_fstar2[tx, ty1, ty2 + 1, ty3] = flux_fv_node2[tx] * (1 - dg_only)
+        end
+        if ty3 + 1 <= tile_width
+            # Set with FV volume fluxes
+            @inbounds shmem_fstar3[tx, ty1, ty2, ty3 + 1] = flux_fv_node3[tx] * (1 - dg_only)
+        end
+    end
+
+    sync_threads()
+
+    # Contribute FV to the volume integrals
+    for tx in axes(du, 1)
+        @inbounds shmem_value[tx, ty1, ty2, ty3] += alpha_element *
+                                                    (inverse_weights[ty1] *
+                                                     (shmem_fstar1[tx, ty1 + 1, ty2, ty3] - shmem_fstar1[tx, ty1, ty2, ty3]) +
+                                                     inverse_weights[ty2] *
+                                                     (shmem_fstar2[tx, ty1, ty2 + 1, ty3] - shmem_fstar2[tx, ty1, ty2, ty3]) +
+                                                     inverse_weights[ty3] *
+                                                     (shmem_fstar3[tx, ty1, ty2, ty3 + 1] - shmem_fstar3[tx, ty1, ty2, ty3])) *
+                                                    (1 - dg_only)
+    end
+
+    # Compute DG volume fluxes
+    for thread in 1:tile_width
+        volume_flux_node1 = volume_flux_dg(u_node,
+                                           get_node_vars(u, equations, thread, ty2, ty3, k),
+                                           1, equations)
+        volume_flux_node2 = volume_flux_dg(u_node,
+                                           get_node_vars(u, equations, ty1, thread, ty3, k),
+                                           2, equations)
+        volume_flux_node3 = volume_flux_dg(u_node,
+                                           get_node_vars(u, equations, ty1, ty2, thread, k),
+                                           3, equations)
+
+        # Contribute DG to the volume integrals
+        for tx in axes(du, 1)
+            @inbounds shmem_value[tx, ty1, ty2, ty3] += (shmem_split[thread, ty1] *
+                                                         (1 - isequal(ty1, thread)) * # set diagonal elements to zeros
+                                                         volume_flux_node1[tx] +
+                                                         shmem_split[thread, ty2] *
+                                                         (1 - isequal(ty2, thread)) * # set diagonal elements to zeros
+                                                         volume_flux_node2[tx] +
+                                                         shmem_split[thread, ty3] *
+                                                         (1 - isequal(ty3, thread)) * # set diagonal elements to zeros
+                                                         volume_flux_node3[tx]) * dg_only +
+                                                        ((1 - alpha_element) * shmem_split[thread, ty1] *
+                                                         (1 - isequal(ty1, thread)) * # set diagonal elements to zeros
+                                                         volume_flux_node1[tx] +
+                                                         (1 - alpha_element) * shmem_split[thread, ty2] *
+                                                         (1 - isequal(ty2, thread)) * # set diagonal elements to zeros
+                                                         volume_flux_node2[tx] +
+                                                         (1 - alpha_element) * shmem_split[thread, ty3] *
+                                                         (1 - isequal(ty3, thread)) * # set diagonal elements to zeros                   
+                                                         volume_flux_node3[tx]) * (1 - dg_only)
+        end
+    end
+
+    # Finalize the values
+    for tx in axes(du, 1)
+        @inbounds du[tx, ty1, ty2, ty3, k] = shmem_value[tx, ty1, ty2, ty3]
+    end
+
     return nothing
 end
 
@@ -1987,58 +2122,73 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
     inverse_weights = dg.basis.inverse_weights
 
-    fstar1_L = cache.fstar1_L
-    fstar1_R = cache.fstar1_R
-    fstar2_L = cache.fstar2_L
-    fstar2_R = cache.fstar2_R
-    fstar3_L = cache.fstar3_L
-    fstar3_R = cache.fstar3_R
-
     # TODO: Get copies of `u` and `du` on both device and host
     # FIXME: Scalar indexing on GPU arrays caused by using GPU cache
     alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
     alpha = CuArray(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
-    volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
-                                      size(u, 2), size(u, 5))
-    volume_flux_arr2 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
-                                      size(u, 2), size(u, 5))
-    volume_flux_arr3 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
-                                      size(u, 2), size(u, 5))
+    thread_per_block = size(du, 2)^3
+    if thread_per_block > MAX_THREADS_PER_BLOCK
+        # TODO: Remove `fstar` from cache initialization
+        fstar1_L = cache.fstar1_L
+        fstar1_R = cache.fstar1_R
+        fstar2_L = cache.fstar2_L
+        fstar2_R = cache.fstar2_R
+        fstar3_L = cache.fstar3_L
+        fstar3_R = cache.fstar3_R
 
-    volume_flux_dgfv_kernel = @cuda launch=false volume_flux_dgfv_kernel!(volume_flux_arr1,
-                                                                          volume_flux_arr2,
-                                                                          volume_flux_arr3,
-                                                                          fstar1_L,
-                                                                          fstar1_R, fstar2_L,
-                                                                          fstar2_R,
-                                                                          fstar3_L, fstar3_R, u,
-                                                                          alpha, atol,
-                                                                          equations,
-                                                                          volume_flux_dg,
-                                                                          volume_flux_fv)
-    volume_flux_dgfv_kernel(volume_flux_arr1, volume_flux_arr2, volume_flux_arr3, fstar1_L,
-                            fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u, alpha, atol,
-                            equations, volume_flux_dg, volume_flux_fv;
-                            kernel_configurator_2d(volume_flux_dgfv_kernel, size(u, 2)^4,
-                                                   size(u, 5))...)
+        volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
+                                          size(u, 2), size(u, 5))
+        volume_flux_arr2 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
+                                          size(u, 2), size(u, 5))
+        volume_flux_arr3 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
+                                          size(u, 2), size(u, 5))
 
-    volume_integral_dgfv_kernel = @cuda launch=false volume_integral_dgfv_kernel!(du, alpha,
-                                                                                  derivative_split,
-                                                                                  inverse_weights,
-                                                                                  volume_flux_arr1,
-                                                                                  volume_flux_arr2,
-                                                                                  volume_flux_arr3,
-                                                                                  fstar1_L, fstar1_R,
-                                                                                  fstar2_L, fstar2_R,
-                                                                                  fstar3_L, fstar3_R,
-                                                                                  atol, equations)
-    volume_integral_dgfv_kernel(du, alpha, derivative_split, inverse_weights, volume_flux_arr1,
-                                volume_flux_arr2, volume_flux_arr3, fstar1_L, fstar1_R,
-                                fstar2_L, fstar2_R, fstar3_L, fstar3_R, atol, equations;
-                                kernel_configurator_3d(volume_integral_dgfv_kernel, size(du, 1),
-                                                       size(du, 2)^3, size(du, 5))...)
+        volume_flux_dgfv_kernel = @cuda launch=false volume_flux_dgfv_kernel!(volume_flux_arr1,
+                                                                              volume_flux_arr2,
+                                                                              volume_flux_arr3,
+                                                                              fstar1_L,
+                                                                              fstar1_R, fstar2_L,
+                                                                              fstar2_R,
+                                                                              fstar3_L, fstar3_R, u,
+                                                                              alpha, atol,
+                                                                              equations,
+                                                                              volume_flux_dg,
+                                                                              volume_flux_fv)
+        volume_flux_dgfv_kernel(volume_flux_arr1, volume_flux_arr2, volume_flux_arr3, fstar1_L,
+                                fstar1_R, fstar2_L, fstar2_R, fstar3_L, fstar3_R, u, alpha, atol,
+                                equations, volume_flux_dg, volume_flux_fv;
+                                kernel_configurator_2d(volume_flux_dgfv_kernel, size(u, 2)^4,
+                                                       size(u, 5))...)
+
+        volume_integral_dgfv_kernel = @cuda launch=false volume_integral_dgfv_kernel!(du, alpha,
+                                                                                      derivative_split,
+                                                                                      inverse_weights,
+                                                                                      volume_flux_arr1,
+                                                                                      volume_flux_arr2,
+                                                                                      volume_flux_arr3,
+                                                                                      fstar1_L, fstar1_R,
+                                                                                      fstar2_L, fstar2_R,
+                                                                                      fstar3_L, fstar3_R,
+                                                                                      atol, equations)
+        volume_integral_dgfv_kernel(du, alpha, derivative_split, inverse_weights, volume_flux_arr1,
+                                    volume_flux_arr2, volume_flux_arr3, fstar1_L, fstar1_R,
+                                    fstar2_L, fstar2_R, fstar3_L, fstar3_R, atol, equations;
+                                    kernel_configurator_3d(volume_integral_dgfv_kernel, size(du, 1),
+                                                           size(du, 2)^3, size(du, 5))...)
+    else
+        shmem_size = (size(u, 2)^2 + size(u, 1) * size(u, 2)^2 * (size(u, 2) + 1) * 3 +
+                      size(u, 1) * size(u, 2)^3) * sizeof(RealT)
+        threads = (1, size(u, 2)^3, 1)
+        blocks = (1, 1, size(u, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
+                                                                                               derivative_split,
+                                                                                               inverse_weights,
+                                                                                               equations,
+                                                                                               volume_flux_dg,
+                                                                                               volume_flux_fv)
+    end
 
     return nothing
 end
@@ -2054,18 +2204,18 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
     inverse_weights = dg.basis.inverse_weights
 
+    # TODO: Get copies of `u` and `du` on both device and host
+    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache
+    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
+    alpha = CuArray(alpha)
+    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
+
     fstar1_L = cache.fstar1_L
     fstar1_R = cache.fstar1_R
     fstar2_L = cache.fstar2_L
     fstar2_R = cache.fstar2_R
     fstar3_L = cache.fstar3_L
     fstar3_R = cache.fstar3_R
-
-    # TODO: Get copies of `u` and `du` on both device and host
-    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache
-    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
-    alpha = CuArray(alpha)
-    atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
                                       size(u, 2), size(u, 5))

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -369,6 +369,7 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
 
     # Load data from global memory into shared memory
     # Transposed access
+    # TODO: Combine into single shared memory
     @inbounds begin
         shmem_split[ty2, ty1] = derivative_split[ty1, ty2]
         shmem_szero[ty2, ty1] = derivative_split[ty1, ty2] *

--- a/test/tree_dgsem_1d/euler_shock.jl
+++ b/test/tree_dgsem_1d/euler_shock.jl
@@ -12,8 +12,10 @@ include("../test_macros.jl")
 
     surface_flux = flux_lax_friedrichs
     volume_flux = flux_shima_etal
+
     basis = LobattoLegendreBasis(3)
     basis_gpu = LobattoLegendreBasisGPU(3)
+
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,
                                              alpha_min = 0.001,
@@ -22,6 +24,7 @@ include("../test_macros.jl")
     volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                      volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
+
     solver = DGSEM(basis, surface_flux, volume_integral)
     solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -12,8 +12,10 @@ include("../test_macros.jl")
 
     surface_flux = flux_lax_friedrichs
     volume_flux = flux_shima_etal
+
     basis = LobattoLegendreBasis(3)
     basis_gpu = LobattoLegendreBasisGPU(3)
+
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,
                                              alpha_min = 0.001,
@@ -22,6 +24,7 @@ include("../test_macros.jl")
     volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                      volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
+
     solver = DGSEM(basis, surface_flux, volume_integral)
     solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -16,6 +16,7 @@ include("../test_macros.jl")
     polydeg = 3
     basis = LobattoLegendreBasis(polydeg)
     basis_gpu = LobattoLegendreBasisGPU(polydeg)
+
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,
                                              alpha_min = 0.001,
@@ -24,6 +25,7 @@ include("../test_macros.jl")
     volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
                                                      volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
+
     solver = DGSEM(basis, surface_flux, volume_integral)
     solver_gpu = DGSEMGPU(basis_gpu, surface_flux, volume_integral)
 


### PR DESCRIPTION
Continue #120 but focus on the frequent use cases without conservative terms.

These cases require high-level optimization to achieve high performance. Benchmark results should be provided for both before and after optimization prior to merging.

Checklist:
- [x] 1D without conservative terms
- [x] 2D without conservative terms
- [x] 3D without conservative terms