### PR TITLE
Enable double caching: CPU cache and GPU cache

### DIFF
--- a/benchmark/advection_basic_1d.jl
+++ b/benchmark/advection_basic_1d.jl
@@ -31,10 +31,9 @@ tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -48,4 +47,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/advection_basic_2d.jl
+++ b/benchmark/advection_basic_2d.jl
@@ -10,7 +10,7 @@ advection_velocity = (0.2f0, -0.7f0)
 equations = LinearScalarAdvectionEquation2D(advection_velocity)
 
 solver = DGSEM(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
-solver = DGSEMGPU(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
+solver_gpu = DGSEMGPU(polydeg = 3, surface_flux = flux_lax_friedrichs, RealT = RealT)
 
 coordinates_min = (-1.0f0, -1.0f0)
 coordinates_max = (1.0f0, 1.0f0)
@@ -31,10 +31,9 @@ tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -48,4 +47,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/advection_basic_3d.jl
+++ b/benchmark/advection_basic_3d.jl
@@ -31,10 +31,9 @@ tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -48,4 +47,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_ec_1d.jl
+++ b/benchmark/euler_ec_1d.jl
@@ -34,10 +34,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -51,4 +50,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_ec_2d.jl
+++ b/benchmark/euler_ec_2d.jl
@@ -37,10 +37,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -54,4 +53,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_ec_3d.jl
+++ b/benchmark/euler_ec_3d.jl
@@ -34,10 +34,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -51,4 +50,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_shock_1d.jl
+++ b/benchmark/euler_shock_1d.jl
@@ -47,10 +47,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -71,4 +70,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_shock_2d.jl
+++ b/benchmark/euler_shock_2d.jl
@@ -47,10 +47,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -71,4 +70,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/euler_shock_3d.jl
+++ b/benchmark/euler_shock_3d.jl
@@ -50,10 +50,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -74,4 +73,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/mhd_ec_1d.jl
+++ b/benchmark/mhd_ec_1d.jl
@@ -35,10 +35,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -52,4 +51,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/mhd_ec_2d.jl
+++ b/benchmark/mhd_ec_2d.jl
@@ -36,10 +36,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -53,4 +52,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/mhd_ec_3d.jl
+++ b/benchmark/mhd_ec_3d.jl
@@ -36,10 +36,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -53,4 +52,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/mhd_shock_2d.jl
+++ b/benchmark/mhd_shock_2d.jl
@@ -47,10 +47,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -71,4 +70,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/mhd_shock_3d.jl
+++ b/benchmark/mhd_shock_3d.jl
@@ -47,10 +47,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -71,4 +70,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/benchmark/shallowwater_shock_1d.jl
+++ b/benchmark/shallowwater_shock_1d.jl
@@ -41,6 +41,7 @@ volume_flux = (flux_wintermeyer_etal, flux_nonconservative_wintermeyer_etal)
 surface_flux = (FluxHydrostaticReconstruction(flux_lax_friedrichs,
                                               hydrostatic_reconstruction_audusse_etal),
                 flux_nonconservative_audusse_etal)
+
 basis = LobattoLegendreBasis(RealT, 4)
 basis_gpu = LobattoLegendreBasisGPU(4, RealT)
 
@@ -79,10 +80,9 @@ t = t_gpu = 0.0f0
 (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on CPU
 ode = semidiscretize(semi, tspan)
@@ -103,4 +103,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 @benchmark CUDA.@sync TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                                       Trixi.have_nonconservative_terms(equations_gpu),
                                                       equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                                      cache_gpu)
+                                                      cache_gpu, cache_cpu)

--- a/examples/shallowwater_ec_2d.jl
+++ b/examples/shallowwater_ec_2d.jl
@@ -86,9 +86,9 @@ end
 # point to the data we want to augment
 u = Trixi.wrap_array(ode.u0, semi)
 # reset the initial condition
-for element in eachelement(semi.solver, semi.cache)
+for element in eachelement(semi.solver, semi.cache_cpu)
     for j in eachnode(semi.solver), i in eachnode(semi.solver)
-        x_node = Trixi.get_node_coords(semi.cache.elements.node_coordinates, equations,
+        x_node = Trixi.get_node_coords(semi.cache_cpu.elements.node_coordinates, equations,
                                        semi.solver, i, j, element)
         u_node = initial_condition_ec_discontinuous_bottom(x_node, first(tspan), element,
                                                            equations)

--- a/profile/profiling.jl
+++ b/profile/profiling.jl
@@ -21,26 +21,20 @@ tspan_gpu = (0.0, 1.0)
 t_gpu = 0.0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
 u_gpu = copy(ode_gpu.u0)
 du_gpu = similar(u_gpu)
 
-# Semidiscretization process
-# Reset du test
-# Function `reset_du!` is deprecated see https://github.com/trixi-gpu/TrixiCUDA.jl/pull/100
-# TrixiCUDA.reset_du!(du_gpu)
-
 # Volume integral test
 TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                 Trixi.have_nonconservative_terms(equations_gpu),
                                 equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                cache_gpu)
+                                cache_gpu, cache_cpu)
 
 # Prolong to interfaces test
 TrixiCUDA.cuda_prolong2interfaces!(u_gpu, mesh_gpu, equations_gpu, cache_gpu)

--- a/profile/profiling_kernel.jl
+++ b/profile/profiling_kernel.jl
@@ -36,10 +36,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -52,4 +51,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                 Trixi.have_nonconservative_terms(equations_gpu),
                                 equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                cache_gpu)
+                                cache_gpu, cache_cpu)

--- a/profile/profiling_kernel2.jl
+++ b/profile/profiling_kernel2.jl
@@ -36,10 +36,9 @@ tspan_gpu = (0.0f0, 1.0f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -52,4 +51,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                 Trixi.have_nonconservative_terms(equations_gpu),
                                 equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                cache_gpu)
+                                cache_gpu, cache_cpu)

--- a/profile/profiling_kernel3.jl
+++ b/profile/profiling_kernel3.jl
@@ -38,10 +38,9 @@ tspan_gpu = (0.0f0, 0.4f0)
 t_gpu = 0.0f0
 
 # Semi on GPU
-equations_gpu = semi_gpu.equations
-mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-boundary_conditions_gpu = semi_gpu.boundary_conditions
-source_terms_gpu = semi_gpu.source_terms
+equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
 # ODE on GPU
 ode_gpu = semidiscretizeGPU(semi_gpu, tspan_gpu)
@@ -54,4 +53,4 @@ du_gpu = TrixiCUDA.wrap_array(du_gpu_, mesh_gpu, equations_gpu, solver_gpu, cach
 TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                 Trixi.have_nonconservative_terms(equations_gpu),
                                 equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                cache_gpu)
+                                cache_gpu, cache_cpu)

--- a/src/TrixiCUDA.jl
+++ b/src/TrixiCUDA.jl
@@ -8,31 +8,36 @@ using CUDA: @cuda, CuArray, HostKernel,
             threadIdx, blockIdx, blockDim, reshape, similar, launch_configuration
 
 # Trixi.jl methods
-using Trixi: allocate_coefficients, compute_coefficients, mesh_equations_solver_cache,
-             flux, ntuple, nnodes, nvariables, nelements,
+using Trixi: allocate_coefficients, compute_coefficients, create_cache,
+             flux, ntuple, nnodes, nvariables, ndofs,
              local_leaf_cells, init_elements, init_interfaces, init_boundaries, init_mortars,
              have_nonconservative_terms, boundary_condition_periodic,
              digest_boundary_conditions, check_periodicity_mesh_boundary_conditions,
              gauss_lobatto_nodes_weights, vandermonde_legendre,
              calc_dsplit, calc_dhat, calc_lhat, polynomial_derivative_matrix,
              calc_forward_upper, calc_forward_lower, calc_reverse_upper, calc_reverse_lower,
-             set_log_type!, set_sqrt_type!
+             calc_error_norms,
+             set_log_type!, set_sqrt_type!,
+             summary_header, summary_line, summary_footer, increment_indent # IO functions
 
 # Trixi.jl structs
 using Trixi: AbstractEquations, AbstractContainer, AbstractMesh, AbstractSemidiscretization,
-             AbstractSurfaceIntegral,
-             True, False, TreeMesh, DG, DGSEM, SemidiscretizationHyperbolic,
+             AbstractSurfaceIntegral, PerformanceCounter,
+             True, False, TreeMesh, StructuredMesh,
+             DG, DGSEM, SemidiscretizationHyperbolic,
              LobattoLegendreBasis, LobattoLegendreMortarL2,
              ElementContainer1D, ElementContainer2D, ElementContainer3D,
              InterfaceContainer1D, InterfaceContainer2D, InterfaceContainer3D,
              BoundaryContainer1D, BoundaryContainer2D, BoundaryContainer3D,
              L2MortarContainer2D, L2MortarContainer3D,
              SurfaceIntegralWeakForm, VolumeIntegralWeakForm,
-             BoundaryConditionPeriodic,
+             BoundaryConditionPeriodic, UnstructuredSortedBoundaryTypes,
              VolumeIntegralFluxDifferencing, VolumeIntegralShockCapturingHG
 
 import Trixi: get_node_vars, get_node_coords, get_surface_node_vars,
-              nelements, ninterfaces, nmortars, wrap_array, wrap_array_native
+              nelements, ninterfaces, nmortars, wrap_array, wrap_array_native,
+              calc_error_norms,
+              mesh_equations_solver_cache
 
 using SciMLBase: ODEProblem, FullSpecialize
 

--- a/src/semidiscretization/semidiscretization_hyperbolic.jl
+++ b/src/semidiscretization/semidiscretization_hyperbolic.jl
@@ -2,6 +2,44 @@
 
 # Similar to `SemidiscretizationHyperbolic` in Trixi.jl 
 # No need to adapt the `SemidiscretizationHyperbolic` struct as it is already GPU compatible
+mutable struct SemidiscretizationHyperbolicGPU{Mesh, Equations, InitialCondition,
+                                               BoundaryConditions,
+                                               SourceTerms, Solver, CacheGPU, CacheCPU} <:
+               AbstractSemidiscretization
+    mesh::Mesh
+    equations::Equations
+
+    # This guy is a bit messy since we abuse it as some kind of "exact solution"
+    # although this doesn't really exist...
+    initial_condition::InitialCondition
+
+    boundary_conditions::BoundaryConditions
+    source_terms::SourceTerms
+    solver::Solver
+    cache_gpu::CacheGPU
+    cache_cpu::CacheCPU
+    performance_counter::PerformanceCounter
+
+    function SemidiscretizationHyperbolicGPU{Mesh, Equations, InitialCondition,
+                                             BoundaryConditions, SourceTerms, Solver,
+                                             CacheGPU, CacheCPU}(mesh::Mesh, equations::Equations,
+                                                                 initial_condition::InitialCondition,
+                                                                 boundary_conditions::BoundaryConditions,
+                                                                 source_terms::SourceTerms,
+                                                                 solver::Solver,
+                                                                 cache_gpu::CacheGPU,
+                                                                 cache_cpu::CacheCPU) where {Mesh, Equations,
+                                                                                             InitialCondition,
+                                                                                             BoundaryConditions,
+                                                                                             SourceTerms,
+                                                                                             Solver,
+                                                                                             CacheGPU, CacheCPU}
+        performance_counter = PerformanceCounter()
+
+        new(mesh, equations, initial_condition, boundary_conditions, source_terms,
+            solver, cache_gpu, cache_cpu, performance_counter)
+    end
+end
 
 # Outer constructor for GPU type
 function SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, solver;
@@ -9,30 +47,131 @@ function SemidiscretizationHyperbolicGPU(mesh, equations, initial_condition, sol
                                          boundary_conditions = boundary_condition_periodic,
                                          RealT = real(solver), # `RealT` is used as real type for node locations etc.
                                          uEltype = RealT, # `uEltype` is used as element type of solutions etc.
-                                         initial_cache = NamedTuple())
+                                         initial_cache_gpu = NamedTuple(),
+                                         initial_cache_cpu = NamedTuple())
     @assert ndims(mesh) == ndims(equations)
 
-    cache = (; create_cache_gpu(mesh, equations, solver, RealT, uEltype)...,
-             initial_cache...)
+    cache_gpu = (; create_cache_gpu(mesh, equations, solver, RealT, uEltype)...,
+                 initial_cache_gpu...)
+    cache_cpu = (; create_cache(mesh, equations, solver, RealT, uEltype)...,
+                 initial_cache_cpu...)
+
     _boundary_conditions = digest_boundary_conditions(boundary_conditions, mesh, solver,
-                                                      cache)
+                                                      cache_cpu)
 
     check_periodicity_mesh_boundary_conditions(mesh, _boundary_conditions)
 
-    # Return the CPU type (GPU compatible)
-    SemidiscretizationHyperbolic{typeof(mesh), typeof(equations),
-                                 typeof(initial_condition),
-                                 typeof(_boundary_conditions), typeof(source_terms),
-                                 typeof(solver), typeof(cache)}(mesh, equations,
-                                                                initial_condition,
-                                                                _boundary_conditions,
-                                                                source_terms, solver,
-                                                                cache)
+    SemidiscretizationHyperbolicGPU{typeof(mesh), typeof(equations),
+                                    typeof(initial_condition), typeof(_boundary_conditions),
+                                    typeof(source_terms), typeof(solver),
+                                    typeof(cache_gpu), typeof(cache_cpu)}(mesh, equations,
+                                                                          initial_condition,
+                                                                          _boundary_conditions,
+                                                                          source_terms, solver,
+                                                                          cache_gpu, cache_cpu)
+end
+
+@inline Base.ndims(semi::SemidiscretizationHyperbolicGPU) = ndims(semi.mesh)
+
+@inline function mesh_equations_solver_cache(semi::SemidiscretizationHyperbolicGPU)
+    # Unpack CPU cache or GPU cache?
+    (; mesh, equations, solver, cache_gpu) = semi
+    return mesh, equations, solver, cache_gpu
+end
+
+function calc_error_norms(func, u_ode, t, analyzer, semi::SemidiscretizationHyperbolicGPU,
+                          cache_analysis)
+    # Unpack CPU cache or GPU cache?
+    (; mesh, equations, initial_condition, solver, cache_cpu) = semi
+    u = wrap_array(u_ode, mesh, equations, solver, cache_cpu)
+
+    calc_error_norms(func, u, t, analyzer, mesh, equations, initial_condition, solver,
+                     cache_cpu, cache_analysis)
 end
 
 # Similar to `compute_coefficients` in Trixi.jl but calls GPU kernel
-function compute_coefficients_gpu(t, semi::SemidiscretizationHyperbolic)
+function compute_coefficients_gpu(t, semi::SemidiscretizationHyperbolicGPU)
 
     # Call `compute_coefficients_gpu` defined in `src/semidiscretization/semidiscretization.jl`
     compute_coefficients_gpu(semi.initial_condition, t, semi)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", semi::SemidiscretizationHyperbolicGPU)
+    @nospecialize semi # reduce precompilation time
+
+    if get(io, :compact, false)
+        show(io, semi)
+    else
+        summary_header(io, "SemidiscretizationHyperbolicGPU")
+        summary_line(io, "#spatial dimensions", ndims(semi.equations))
+        summary_line(io, "mesh", semi.mesh)
+        summary_line(io, "equations", semi.equations |> typeof |> nameof)
+        summary_line(io, "initial condition", semi.initial_condition)
+
+        print_boundary_conditions(io, semi)
+
+        summary_line(io, "source terms", semi.source_terms)
+        summary_line(io, "solver", semi.solver |> typeof |> nameof)
+        summary_line(io, "total #DOFs per field", ndofs(semi))
+        summary_footer(io)
+    end
+end
+
+# type alias for dispatch in printing of boundary conditions
+#! format: off
+const SemiHypMeshBCSolver{Mesh, BoundaryConditions, Solver} =
+        SemidiscretizationHyperbolicGPU{Mesh,
+                                        Equations,
+                                        InitialCondition,
+                                        BoundaryConditions,
+                                        SourceTerms,
+                                        Solver} where {Equations,
+                                                    InitialCondition,
+                                                    SourceTerms}
+#! format: on
+
+# generic fallback: print the type of semi.boundary_condition.
+function print_boundary_conditions(io, semi::SemiHypMeshBCSolver)
+    summary_line(io, "boundary conditions", typeof(semi.boundary_conditions))
+end
+
+function print_boundary_conditions(io,
+                                   semi::SemiHypMeshBCSolver{<:Any,
+                                                             <:UnstructuredSortedBoundaryTypes})
+    (; boundary_conditions) = semi
+    (; boundary_dictionary) = boundary_conditions
+    summary_line(io, "boundary conditions", length(boundary_dictionary))
+    for (boundary_name, boundary_condition) in boundary_dictionary
+        summary_line(increment_indent(io), boundary_name, typeof(boundary_condition))
+    end
+end
+
+function print_boundary_conditions(io, semi::SemiHypMeshBCSolver{<:Any, <:NamedTuple})
+    (; boundary_conditions) = semi
+    summary_line(io, "boundary conditions", length(boundary_conditions))
+    bc_names = keys(boundary_conditions)
+    for (i, bc_name) in enumerate(bc_names)
+        summary_line(increment_indent(io), String(bc_name),
+                     typeof(boundary_conditions[i]))
+    end
+end
+
+function print_boundary_conditions(io,
+                                   semi::SemiHypMeshBCSolver{<:Union{TreeMesh,
+                                                                     StructuredMesh},
+                                                             <:Union{Tuple, NamedTuple,
+                                                                     AbstractArray}})
+    summary_line(io, "boundary conditions", 2 * ndims(semi))
+    bcs = semi.boundary_conditions
+
+    summary_line(increment_indent(io), "negative x", bcs[1])
+    summary_line(increment_indent(io), "positive x", bcs[2])
+    if ndims(semi) > 1
+        summary_line(increment_indent(io), "negative y", bcs[3])
+        summary_line(increment_indent(io), "positive y", bcs[4])
+    end
+    if ndims(semi) > 2
+        summary_line(increment_indent(io), "negative z", bcs[5])
+        summary_line(increment_indent(io), "positive z", bcs[6])
+    end
 end

--- a/src/solvers/basis_lobatto_legendre.jl
+++ b/src/solvers/basis_lobatto_legendre.jl
@@ -44,8 +44,9 @@ function LobattoLegendreBasisGPU(polydeg::Integer, RealT = Float64) # how about 
     weights = CuArray{RealT}(weights_)
     inverse_weights = CuArray{RealT}(inverse_weights_)
 
-    inverse_vandermonde_legendre = CuArray{RealT}(inverse_vandermonde_legendre_)
-    # boundary_interpolation = CuArray(boundary_interpolation_) # avoid scalar indexing
+    # Avoid scalar indexing
+    # inverse_vandermonde_legendre = CuArray{RealT}(inverse_vandermonde_legendre_)
+    # boundary_interpolation = CuArray(boundary_interpolation_)
 
     derivative_matrix = CuArray{RealT}(derivative_matrix_)
     derivative_split = CuArray{RealT}(derivative_split_)
@@ -54,11 +55,11 @@ function LobattoLegendreBasisGPU(polydeg::Integer, RealT = Float64) # how about 
 
     # TODO: Implement a custom struct for finer control over data types
     return LobattoLegendreBasis{RealT, nnodes_, typeof(nodes),
-                                typeof(inverse_vandermonde_legendre),
+                                typeof(inverse_vandermonde_legendre_),
                                 typeof(boundary_interpolation_),
                                 typeof(derivative_matrix)}(nodes_, weights,
                                                            inverse_weights,
-                                                           inverse_vandermonde_legendre,
+                                                           inverse_vandermonde_legendre_,
                                                            boundary_interpolation_,
                                                            derivative_matrix,
                                                            derivative_split,

--- a/src/solvers/cache.jl
+++ b/src/solvers/cache.jl
@@ -56,7 +56,6 @@ function create_cache_gpu(mesh::TreeMesh{1}, equations,
                              VolumeIntegralFluxDifferencing(volume_integral.volume_flux_dg),
                              dg, uEltype, cache)
 
-    # Remove `element_ids_dg` and `element_ids_dgfv` here
     return (; cache..., fstar1_L, fstar1_R)
 end
 

--- a/src/solvers/cache.jl
+++ b/src/solvers/cache.jl
@@ -35,7 +35,7 @@ function create_cache_gpu(mesh::TreeMesh{1}, equations, dg::DG, RealT, uEltype)
 
     # Add specialized parts of the cache required to compute the volume integral etc.
     cache = (; cache_gpu...,
-             create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_cpu)...)
+             create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_gpu)...)
 
     return cache
 end
@@ -87,8 +87,8 @@ function create_cache_gpu(mesh::TreeMesh{2}, equations,
 
     # Add specialized parts of the cache required to compute the volume integral etc.
     cache_gpu = (; cache_gpu...,
-                 create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_cpu)...)
-    cache = (; cache_gpu..., create_cache_gpu(mesh, equations, dg.mortar, uEltype, cache_cpu)...)
+                 create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_gpu)...)
+    cache = (; cache_gpu..., create_cache_gpu(mesh, equations, dg.mortar, uEltype, cache_gpu)...)
 
     return cache
 end
@@ -160,8 +160,8 @@ function create_cache_gpu(mesh::TreeMesh{3}, equations,
 
     # Add specialized parts of the cache required to compute the volume integral etc.
     cache_gpu = (; cache_gpu...,
-                 create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_cpu)...)
-    cache = (; cache_gpu..., create_cache_gpu(mesh, equations, dg.mortar, uEltype, cache_cpu)...)
+                 create_cache_gpu(mesh, equations, dg.volume_integral, dg, uEltype, cache_gpu)...)
+    cache = (; cache_gpu..., create_cache_gpu(mesh, equations, dg.mortar, uEltype, cache_gpu)...)
 
     return cache
 end

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -4,7 +4,7 @@
                             dg::DG, cache)
     # TODO: Assert array length before calling `reshape`
     u_ode = reshape(u_ode, nvariables(equations), ntuple(_ -> nnodes(dg), ndims(mesh))...,
-                    nelements(dg, cache))
+                    nelements(cache.elements))
 
     return u_ode
 end
@@ -15,7 +15,7 @@ end
                                    dg::DG, cache)
     # TODO: Assert array length before calling `reshape`
     u_ode = reshape(u_ode, nvariables(equations), ntuple(_ -> nnodes(dg), ndims(mesh))...,
-                    nelements(dg, cache))
+                    nelements(cache.elements))
 
     return u_ode
 end

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -835,7 +835,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
-                               equations, volume_integral::VolumeIntegralWeakForm, dg::DGSEM, cache)
+                               equations, volume_integral::VolumeIntegralWeakForm, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     derivative_dhat = dg.basis.derivative_dhat
 
     # The maximum number of threads per block is the dominant factor when choosing the optimization 
@@ -872,7 +873,7 @@ end
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False,
                                equations, volume_integral::VolumeIntegralFluxDifferencing,
-                               dg::DGSEM, cache)
+                               dg::DGSEM, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -908,7 +909,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     symmetric_flux, nonconservative_flux = dg.volume_integral.volume_flux
@@ -953,7 +955,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, volume_flux_fv = dg.volume_integral.volume_flux_dg,
@@ -963,16 +966,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     inverse_weights = dg.basis.inverse_weights
 
     # TODO: Get copies of `u` and `du` on both device and host
-    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache
-    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
+    alpha = indicator(Array(u), mesh, equations, dg, cache_cpu)
     alpha = CuArray(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)
     if thread_per_block > MAX_THREADS_PER_BLOCK
         # TODO: Remove `fstar` from cache initialization
-        fstar1_L = cache.fstar1_L
-        fstar1_R = cache.fstar1_R
+        fstar1_L = cache_gpu.fstar1_L
+        fstar1_R = cache_gpu.fstar1_R
 
         volume_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
 
@@ -1013,7 +1015,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, noncons_flux_dg = dg.volume_integral.volume_flux_dg
@@ -1023,13 +1026,12 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     inverse_weights = dg.basis.inverse_weights
 
     # TODO: Get copies of `u` and `du` on both device and host
-    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache
-    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
+    alpha = indicator(Array(u), mesh, equations, dg, cache_cpu)
     alpha = CuArray(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
-    fstar1_L = cache.fstar1_L
-    fstar1_R = cache.fstar1_R
+    fstar1_L = cache_gpu.fstar1_L
+    fstar1_R = cache_gpu.fstar1_R
 
     volume_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
     noncons_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
@@ -1315,28 +1317,28 @@ end
 
 # See also `rhs!` function in Trixi.jl
 function rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
-                  source_terms::Source, dg::DGSEM, cache) where {Source}
+                  source_terms::Source, dg::DGSEM, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 
     # reset_du!(du) is now fused into the next kernel, 
     # removing the need for a separate function call.
 
     cuda_volume_integral!(du, u, mesh, have_nonconservative_terms(equations), equations,
-                          dg.volume_integral, dg, cache)
+                          dg.volume_integral, dg, cache_gpu, cache_cpu)
 
-    cuda_prolong2interfaces!(u, mesh, equations, cache)
+    cuda_prolong2interfaces!(u, mesh, equations, cache_gpu)
 
-    cuda_interface_flux!(mesh, have_nonconservative_terms(equations), equations, dg, cache)
+    cuda_interface_flux!(mesh, have_nonconservative_terms(equations), equations, dg, cache_gpu)
 
-    cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache)
+    cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache_gpu)
 
     cuda_boundary_flux!(t, mesh, boundary_conditions,
-                        have_nonconservative_terms(equations), equations, dg, cache)
+                        have_nonconservative_terms(equations), equations, dg, cache_gpu)
 
-    cuda_surface_integral!(du, mesh, equations, dg, cache)
+    cuda_surface_integral!(du, mesh, equations, dg, cache_gpu)
 
-    cuda_jacobian!(du, mesh, equations, cache)
+    cuda_jacobian!(du, mesh, equations, cache_gpu)
 
-    cuda_sources!(du, u, t, source_terms, equations, cache)
+    cuda_sources!(du, u, t, source_terms, equations, cache_gpu)
 
     return nothing
 end

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -1337,7 +1337,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, equations,
-                               volume_integral::VolumeIntegralWeakForm, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralWeakForm, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     derivative_dhat = dg.basis.derivative_dhat
 
     # The maximum number of threads per block is the dominant factor when choosing the optimization 
@@ -1376,7 +1377,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -1416,7 +1418,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralFluxDifferencing, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     symmetric_flux, nonconservative_flux = dg.volume_integral.volume_flux
@@ -1473,7 +1476,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, volume_flux_fv = dg.volume_integral.volume_flux_dg,
@@ -1483,18 +1487,17 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     inverse_weights = dg.basis.inverse_weights
 
     # TODO: Get copies of `u` and `du` on both device and host
-    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache 
-    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
+    alpha = indicator(Array(u), mesh, equations, dg, cache_cpu)
     alpha = CuArray(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)^2
     if thread_per_block > MAX_THREADS_PER_BLOCK
         # TODO: Remove `fstar` from cache initialization
-        fstar1_L = cache.fstar1_L
-        fstar1_R = cache.fstar1_R
-        fstar2_L = cache.fstar2_L
-        fstar2_R = cache.fstar2_R
+        fstar1_L = cache_gpu.fstar1_L
+        fstar1_R = cache_gpu.fstar1_R
+        fstar2_L = cache_gpu.fstar2_L
+        fstar2_R = cache_gpu.fstar2_R
 
         volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
                                           size(u, 4))
@@ -1545,7 +1548,8 @@ end
 
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM, cache)
+                               volume_integral::VolumeIntegralShockCapturingHG, dg::DGSEM,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, noncons_flux_dg = dg.volume_integral.volume_flux_dg
@@ -1555,15 +1559,14 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     inverse_weights = dg.basis.inverse_weights
 
     # TODO: Get copies of `u` and `du` on both device and host
-    # FIXME: Scalar indexing on GPU arrays caused by using GPU cache 
-    alpha = indicator(Array(u), mesh, equations, dg, cache) # GPU cache
+    alpha = indicator(Array(u), mesh, equations, dg, cache_cpu)
     alpha = CuArray(alpha)
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
-    fstar1_L = cache.fstar1_L
-    fstar1_R = cache.fstar1_R
-    fstar2_L = cache.fstar2_L
-    fstar2_R = cache.fstar2_R
+    fstar1_L = cache_gpu.fstar1_L
+    fstar1_R = cache_gpu.fstar1_R
+    fstar2_L = cache_gpu.fstar2_L
+    fstar2_R = cache_gpu.fstar2_R
 
     volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
                                       size(u, 4))
@@ -2053,33 +2056,33 @@ end
 
 # See also `rhs!` function in Trixi.jl
 function rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations, boundary_conditions,
-                  source_terms::Source, dg::DGSEM, cache) where {Source}
+                  source_terms::Source, dg::DGSEM, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 
     # reset_du!(du) is now fused into the next kernel, 
     # removing the need for a separate function call.
 
     cuda_volume_integral!(du, u, mesh, have_nonconservative_terms(equations), equations,
-                          dg.volume_integral, dg, cache)
+                          dg.volume_integral, dg, cache_gpu, cache_cpu)
 
-    cuda_prolong2interfaces!(u, mesh, equations, cache)
+    cuda_prolong2interfaces!(u, mesh, equations, cache_gpu)
 
-    cuda_interface_flux!(mesh, have_nonconservative_terms(equations), equations, dg, cache)
+    cuda_interface_flux!(mesh, have_nonconservative_terms(equations), equations, dg, cache_gpu)
 
-    cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache)
+    cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache_gpu)
 
     cuda_boundary_flux!(t, mesh, boundary_conditions,
-                        have_nonconservative_terms(equations), equations, dg, cache)
+                        have_nonconservative_terms(equations), equations, dg, cache_gpu)
 
-    cuda_prolong2mortars!(u, mesh, check_cache_mortars(cache), dg, cache)
+    cuda_prolong2mortars!(u, mesh, check_cache_mortars(cache_gpu), dg, cache_gpu)
 
-    cuda_mortar_flux!(mesh, check_cache_mortars(cache), have_nonconservative_terms(equations),
-                      equations, dg, cache)
+    cuda_mortar_flux!(mesh, check_cache_mortars(cache_gpu), have_nonconservative_terms(equations),
+                      equations, dg, cache_gpu)
 
-    cuda_surface_integral!(du, mesh, equations, dg, cache)
+    cuda_surface_integral!(du, mesh, equations, dg, cache_gpu)
 
-    cuda_jacobian!(du, mesh, equations, cache)
+    cuda_jacobian!(du, mesh, equations, cache_gpu)
 
-    cuda_sources!(du, u, t, source_terms, equations, cache)
+    cuda_sources!(du, u, t, source_terms, equations, cache_gpu)
 
     return nothing
 end

--- a/src/solvers/solvers.jl
+++ b/src/solvers/solvers.jl
@@ -11,21 +11,23 @@ include("dg.jl")
 include("dgsem.jl")
 
 # See also `rhs!` function in Trixi.jl
-function rhs_gpu!(du_ode, u_ode, semi::SemidiscretizationHyperbolic, t)
-    (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
+function rhs_gpu!(du_ode, u_ode, semi::SemidiscretizationHyperbolicGPU, t)
+    (; mesh, equations, boundary_conditions, source_terms, solver,
+    cache_gpu, cache_cpu) = semi
 
     # In Trixi.jl, function `wrap_array` is called to adapt adaptive mesh refinement (AMR).
     # For more details, see https://trixi-framework.github.io/Trixi.jl/stable/conventions/#Array-types-and-wrapping
-    u = wrap_array(u_ode, mesh, equations, solver, cache)
-    du = wrap_array(du_ode, mesh, equations, solver, cache)
+    u = wrap_array(u_ode, mesh, equations, solver, cache_gpu)
+    du = wrap_array(du_ode, mesh, equations, solver, cache_gpu)
 
-    rhs_gpu!(du, u, t, mesh, equations, boundary_conditions, source_terms, solver, cache)
+    rhs_gpu!(du, u, t, mesh, equations, boundary_conditions, source_terms, solver,
+             cache_gpu, cache_cpu)
 
     return nothing
 end
 
 # See also `semidiscretize` function in Trixi.jl
-function semidiscretizeGPU(semi::SemidiscretizationHyperbolic, tspan)
+function semidiscretizeGPU(semi::SemidiscretizationHyperbolicGPU, tspan)
     # Computing coefficients on GPUs may not be as fast as on CPUs due to the overhead. 
     # Therefore, we currently use the GPU version. Note that the actual speedup on GPUs
     # largely depends on the problem size (e.g., large arrays typically gain much more 

--- a/test/tree_dgsem_1d/advection_basic.jl
+++ b/test/tree_dgsem_1d/advection_basic.jl
@@ -31,10 +31,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -57,7 +56,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/advection_extended.jl
+++ b/test/tree_dgsem_1d/advection_extended.jl
@@ -36,10 +36,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -62,7 +61,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/burgers_basic.jl
+++ b/test/tree_dgsem_1d/burgers_basic.jl
@@ -31,10 +31,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -57,7 +56,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/burgers_rarefraction.jl
+++ b/test/tree_dgsem_1d/burgers_rarefraction.jl
@@ -70,10 +70,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -96,7 +95,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/burgers_shock.jl
+++ b/test/tree_dgsem_1d/burgers_shock.jl
@@ -71,10 +71,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -97,7 +96,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/euler_blast_wave.jl
+++ b/test/tree_dgsem_1d/euler_blast_wave.jl
@@ -55,10 +55,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -81,7 +80,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/euler_ec.jl
+++ b/test/tree_dgsem_1d/euler_ec.jl
@@ -32,10 +32,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -58,7 +57,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/euler_shock.jl
+++ b/test/tree_dgsem_1d/euler_shock.jl
@@ -44,10 +44,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -70,7 +69,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/euler_source_terms.jl
+++ b/test/tree_dgsem_1d/euler_source_terms.jl
@@ -31,10 +31,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -57,7 +56,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_1d/euler_source_terms_nonperiodic.jl
@@ -38,10 +38,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -64,7 +63,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/eulermulti_ec.jl
+++ b/test/tree_dgsem_1d/eulermulti_ec.jl
@@ -38,10 +38,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -64,7 +63,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/eulermulti_es.jl
+++ b/test/tree_dgsem_1d/eulermulti_es.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/eulerquasi_ec.jl
+++ b/test/tree_dgsem_1d/eulerquasi_ec.jl
@@ -42,10 +42,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -68,7 +67,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/eulerquasi_source_terms.jl
+++ b/test/tree_dgsem_1d/eulerquasi_source_terms.jl
@@ -35,10 +35,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -61,7 +60,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_harmonic_nonperiodic.jl
@@ -50,10 +50,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -76,7 +75,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_1d/hypdiff_nonperiodic.jl
@@ -36,10 +36,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -62,7 +61,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_1d/mhd_alfven_wave.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/mhd_ec.jl
+++ b/test/tree_dgsem_1d/mhd_ec.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_1d/shallowwater_shock.jl
+++ b/test/tree_dgsem_1d/shallowwater_shock.jl
@@ -74,10 +74,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -100,7 +99,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/advection_basic.jl
+++ b/test/tree_dgsem_2d/advection_basic.jl
@@ -31,10 +31,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -57,7 +56,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/advection_mortar.jl
+++ b/test/tree_dgsem_2d/advection_mortar.jl
@@ -32,10 +32,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -58,7 +57,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/euler_blob_mortar.jl
+++ b/test/tree_dgsem_2d/euler_blob_mortar.jl
@@ -76,10 +76,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -102,7 +101,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/euler_ec.jl
+++ b/test/tree_dgsem_2d/euler_ec.jl
@@ -35,10 +35,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -61,7 +60,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -44,10 +44,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -70,7 +69,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/euler_source_terms.jl
+++ b/test/tree_dgsem_2d/euler_source_terms.jl
@@ -30,10 +30,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -56,7 +55,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
@@ -40,10 +40,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -66,7 +65,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/eulermulti_ec.jl
+++ b/test/tree_dgsem_2d/eulermulti_ec.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/eulermulti_es.jl
+++ b/test/tree_dgsem_2d/eulermulti_es.jl
@@ -38,10 +38,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -64,7 +63,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
@@ -39,10 +39,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -65,7 +64,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave.jl
@@ -35,10 +35,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -61,7 +60,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
@@ -40,10 +40,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -66,7 +65,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/mhd_ec.jl
+++ b/test/tree_dgsem_2d/mhd_ec.jl
@@ -34,10 +34,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -60,7 +59,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -44,10 +44,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -70,7 +69,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/shallowwater_ec.jl
+++ b/test/tree_dgsem_2d/shallowwater_ec.jl
@@ -34,10 +34,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -60,7 +59,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/shallowwater_source_terms.jl
+++ b/test/tree_dgsem_2d/shallowwater_source_terms.jl
@@ -37,10 +37,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -63,7 +62,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
@@ -41,10 +41,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -67,7 +66,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/advection_basic.jl
+++ b/test/tree_dgsem_3d/advection_basic.jl
@@ -31,10 +31,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -57,7 +56,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/advection_mortar.jl
+++ b/test/tree_dgsem_3d/advection_mortar.jl
@@ -34,10 +34,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -60,7 +59,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/euler_convergence.jl
+++ b/test/tree_dgsem_3d/euler_convergence.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/euler_ec.jl
+++ b/test/tree_dgsem_3d/euler_ec.jl
@@ -32,10 +32,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -58,7 +57,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/euler_mortar.jl
+++ b/test/tree_dgsem_3d/euler_mortar.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -45,10 +45,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -71,7 +70,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/euler_source_terms.jl
+++ b/test/tree_dgsem_3d/euler_source_terms.jl
@@ -33,10 +33,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -59,7 +58,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
@@ -40,10 +40,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -66,7 +65,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave.jl
@@ -34,10 +34,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -60,7 +59,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
@@ -39,10 +39,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -65,7 +64,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/mhd_ec.jl
+++ b/test/tree_dgsem_3d/mhd_ec.jl
@@ -34,10 +34,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -60,7 +59,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -44,10 +44,9 @@ include("../test_macros.jl")
     (; mesh, equations, boundary_conditions, source_terms, solver, cache) = semi
 
     # Semi on GPU
-    equations_gpu = semi_gpu.equations
-    mesh_gpu, solver_gpu, cache_gpu = semi_gpu.mesh, semi_gpu.solver, semi_gpu.cache
-    boundary_conditions_gpu = semi_gpu.boundary_conditions
-    source_terms_gpu = semi_gpu.source_terms
+    equations_gpu, mesh_gpu, solver_gpu = semi_gpu.equations, semi_gpu.mesh, semi_gpu.solver
+    cache_gpu, cache_cpu = semi_gpu.cache_gpu, semi_gpu.cache_cpu
+    boundary_conditions_gpu, source_terms_gpu = semi_gpu.boundary_conditions, semi_gpu.source_terms
 
     # ODE on CPU
     ode = semidiscretize(semi, tspan)
@@ -70,7 +69,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_volume_integral!(du_gpu, u_gpu, mesh_gpu,
                                     Trixi.have_nonconservative_terms(equations_gpu),
                                     equations_gpu, solver_gpu.volume_integral, solver_gpu,
-                                    cache_gpu)
+                                    cache_gpu, cache_cpu)
     Trixi.calc_volume_integral!(du, u, mesh, Trixi.have_nonconservative_terms(equations),
                                 equations, solver.volume_integral, solver, cache)
     @test_approx (du_gpu, du)


### PR DESCRIPTION
Fix #59. 

The GPU-only cache strategy causes the indicator functions to run slower on GPU arrays. We are enabling an additional cache on the CPU as a hotfix strategy. However, not all data needs to be stored on both the GPU and CPU, so we should differentiate them in the future.

The latest benchmark results for Euler equations for shock capturing should be given here.