### PR TITLE
Bump compat for Trixi to 0.9.15

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ BenchmarkTools = "1"
 CUDA = "5"
 SciMLBase = "2"
 StaticArrays = "1"
-Trixi = "0.8, 0.9.8 - 0.9.8"
+Trixi = "0.9.8 - 0.9.14"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ BenchmarkTools = "1"
 CUDA = "5"
 SciMLBase = "2"
 StaticArrays = "1"
-Trixi = "0.9.8 - 0.9.14"
+Trixi = "0.9.10 - 0.9.15"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ using Trixi, TrixiCUDA
 using OrdinaryDiffEq
 
 # Currently skip the issue of scalar indexing
-# See issues https://github.com/trixi-gpu/TrixiCUDA.jl/issues/59
-# https://github.com/trixi-gpu/TrixiCUDA.jl/issues/113
-# https://github.com/trixi-gpu/TrixiCUDA.jl/issues/118
+# See issues https://github.com/trixi-gpu/TrixiCUDA.jl/issues/113
+# and https://github.com/trixi-gpu/TrixiCUDA.jl/issues/118
 using CUDA
 CUDA.allowscalar(true)
 

--- a/src/solvers/basis_lobatto_legendre.jl
+++ b/src/solvers/basis_lobatto_legendre.jl
@@ -39,7 +39,8 @@ function LobattoLegendreBasisGPU(polydeg::Integer, RealT = Float64) # how about 
     derivative_dhat_ = calc_dhat(nodes_, weights_)
 
     # Convert to GPU arrays
-    # TODO: `RealT` can be removed once Trixi.jl can be updated to the latest one
+    # TODO: `RealT` can be removed once it is confirmed that theses arrays are
+    # type-stable in above process
     nodes = CuArray{RealT}(nodes_)
     weights = CuArray{RealT}(weights_)
     inverse_weights = CuArray{RealT}(inverse_weights_)
@@ -96,7 +97,8 @@ function MortarL2GPU(basis::LobattoLegendreBasis)
     reverse_lower_ = calc_reverse_lower(nnodes_, Val(:gauss), RealT)
 
     # Convert to GPU arrays
-    # TODO: `RealT` can be removed once Trixi.jl can be updated to the latest one
+    # TODO: `RealT` can be removed once it is confirmed that theses arrays are
+    # type-stable in above process
     forward_upper = CuArray{RealT}(forward_upper_)
     forward_lower = CuArray{RealT}(forward_lower_)
     reverse_upper = CuArray{RealT}(reverse_upper_)

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -47,10 +47,10 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_dhat = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_dhat = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_flux = @cuDynamicSharedMem(eltype(du),
-                                     (size(du, 1), tile_width), offset)
+    shmem_flux = CuDynamicSharedArray(eltype(du),
+                                      (size(du, 1), tile_width), offset)
 
     # Get thread and block indices only we need to save registers
     tx, ty = threadIdx().x, threadIdx().y
@@ -138,10 +138,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width),
+                                       offset)
 
     # Get thread and block indices only we need to save registers
     ty = threadIdx().y
@@ -247,10 +247,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width),
+                                       offset)
 
     # Get thread and block indices only we need to save registers
     ty = threadIdx().y
@@ -395,13 +395,13 @@ function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_fstar1 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width + 1),
-                                       offset)
+    shmem_fstar1 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width + 1),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * (tile_width + 1)
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width),
+                                       offset)
 
     # Get thread and block indices only we need to save registers
     ty = threadIdx().y

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -60,11 +60,11 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_dhat = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_dhat = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_flux = @cuDynamicSharedMem(eltype(du),
-                                     (size(du, 1), tile_width, tile_width, 2),
-                                     offset)
+    shmem_flux = CuDynamicSharedArray(eltype(du),
+                                      (size(du, 1), tile_width, tile_width, 2),
+                                      offset)
 
     # Get thread and block indices only we need to save registers
     tx, ty = threadIdx().x, threadIdx().y
@@ -171,10 +171,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y
@@ -305,10 +305,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y
@@ -507,16 +507,16 @@ function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split,
 
     # Allocate dynamic shared memory
     # TODO: Combine `fstar` into single allocation
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_fstar1 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width + 1, tile_width),
-                                       offset)
+    shmem_fstar1 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width + 1, tile_width),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * (tile_width + 1) * tile_width
-    shmem_fstar2 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width + 1),
-                                       offset)
+    shmem_fstar2 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width + 1),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * tile_width * (tile_width + 1)
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -70,11 +70,11 @@ function flux_weak_form_kernel!(du, u, derivative_dhat,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_dhat = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_dhat = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_flux = @cuDynamicSharedMem(eltype(du),
-                                     (size(du, 1), tile_width, tile_width, tile_width, 3),
-                                     offset)
+    shmem_flux = CuDynamicSharedArray(eltype(du),
+                                      (size(du, 1), tile_width, tile_width, tile_width, 3),
+                                      offset)
 
     # Get thread and block indices only we need save registers
     tx, ty = threadIdx().x, threadIdx().y
@@ -194,10 +194,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y
@@ -347,10 +347,10 @@ function volume_flux_integral_kernel!(du, u, derivative_split,
     offset = 0 # offset bytes for shared memory
 
     # Allocate dynamic shared memory
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y
@@ -597,19 +597,19 @@ function volume_flux_integral_dgfv_kernel!(du, u, alpha, atol, derivative_split,
 
     # Allocate dynamic shared memory
     # TODO: Combine `fstar` into single allocation
-    shmem_split = @cuDynamicSharedMem(eltype(du), (tile_width, tile_width))
+    shmem_split = CuDynamicSharedArray(eltype(du), (tile_width, tile_width))
     offset += sizeof(eltype(du)) * tile_width^2
-    shmem_fstar1 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width + 1, tile_width, tile_width),
-                                       offset)
+    shmem_fstar1 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width + 1, tile_width, tile_width),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * (tile_width + 1) * tile_width * tile_width
-    shmem_fstar2 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width + 1, tile_width),
-                                       offset)
+    shmem_fstar2 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width + 1, tile_width),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * tile_width * (tile_width + 1) * tile_width
-    shmem_fstar3 = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width + 1),
-                                       offset)
+    shmem_fstar3 = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width, tile_width + 1),
+                                        offset)
     offset += sizeof(eltype(du)) * size(du, 1) * tile_width * tile_width * (tile_width + 1)
-    shmem_value = @cuDynamicSharedMem(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
-                                      offset)
+    shmem_value = CuDynamicSharedArray(eltype(du), (size(du, 1), tile_width, tile_width, tile_width),
+                                       offset)
 
     # Get thread and block indices only we need save registers
     ty = threadIdx().y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 module TestTrixiCUDA
 
 using Test: @testset
+using CUDA
+# Currently we need to allow scalar indexing on GPU arrays for the tests to pass,
+# once the issues are resolved, this line can be removed.
+CUDA.allowscalar(true)
 
 @testset "TrixiCUDA.jl" begin
     # include("./tree_dgsem_1d/tree_dgsem_1d.jl")

--- a/test/tree_dgsem_1d/burgers_shock.jl
+++ b/test/tree_dgsem_1d/burgers_shock.jl
@@ -21,7 +21,7 @@ include("../test_macros.jl")
     surface_flux = flux_lax_friedrichs
 
     volume_integral = VolumeIntegralShockCapturingHG(indicator_sc;
-                                                     volume_flux_dg = surface_flux,
+                                                     volume_flux_dg = volume_flux,
                                                      volume_flux_fv = surface_flux)
 
     solver = DGSEM(basis, surface_flux, volume_integral)

--- a/test/tree_dgsem_2d/advection_basic.jl
+++ b/test/tree_dgsem_2d/advection_basic.jl
@@ -90,8 +90,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/advection_mortar.jl
+++ b/test/tree_dgsem_2d/advection_mortar.jl
@@ -91,8 +91,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/euler_blob_mortar.jl
+++ b/test/tree_dgsem_2d/euler_blob_mortar.jl
@@ -135,8 +135,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/euler_ec.jl
+++ b/test/tree_dgsem_2d/euler_ec.jl
@@ -94,8 +94,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/euler_shock.jl
+++ b/test/tree_dgsem_2d/euler_shock.jl
@@ -103,8 +103,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/euler_source_terms.jl
+++ b/test/tree_dgsem_2d/euler_source_terms.jl
@@ -89,8 +89,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/euler_source_terms_nonperiodic.jl
@@ -99,8 +99,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/eulermulti_ec.jl
+++ b/test/tree_dgsem_2d/eulermulti_ec.jl
@@ -92,8 +92,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/eulermulti_es.jl
+++ b/test/tree_dgsem_2d/eulermulti_es.jl
@@ -97,8 +97,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_2d/hypdiff_nonperiodic.jl
@@ -98,8 +98,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave.jl
@@ -94,8 +94,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_2d/mhd_alfven_wave_mortar.jl
@@ -99,8 +99,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/mhd_ec.jl
+++ b/test/tree_dgsem_2d/mhd_ec.jl
@@ -93,8 +93,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/mhd_shock.jl
+++ b/test/tree_dgsem_2d/mhd_shock.jl
@@ -103,8 +103,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/shallowwater_ec.jl
+++ b/test/tree_dgsem_2d/shallowwater_ec.jl
@@ -93,8 +93,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/shallowwater_source_terms.jl
+++ b/test/tree_dgsem_2d/shallowwater_source_terms.jl
@@ -96,8 +96,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
+++ b/test/tree_dgsem_2d/shawllowwater_source_terms_nonperiodic.jl
@@ -100,8 +100,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar,
-                           solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper, cache.mortars.u_upper)
     @test_approx (cache_gpu.mortars.u_lower, cache.mortars.u_lower)
 

--- a/test/tree_dgsem_3d/advection_basic.jl
+++ b/test/tree_dgsem_3d/advection_basic.jl
@@ -90,8 +90,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/advection_mortar.jl
+++ b/test/tree_dgsem_3d/advection_mortar.jl
@@ -93,8 +93,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/euler_convergence.jl
+++ b/test/tree_dgsem_3d/euler_convergence.jl
@@ -92,8 +92,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/euler_ec.jl
+++ b/test/tree_dgsem_3d/euler_ec.jl
@@ -91,8 +91,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/euler_mortar.jl
+++ b/test/tree_dgsem_3d/euler_mortar.jl
@@ -92,8 +92,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/euler_shock.jl
+++ b/test/tree_dgsem_3d/euler_shock.jl
@@ -104,8 +104,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/euler_source_terms.jl
+++ b/test/tree_dgsem_3d/euler_source_terms.jl
@@ -92,8 +92,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
+++ b/test/tree_dgsem_3d/hypdiff_nonperiodic.jl
@@ -99,8 +99,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/mhd_alfven_wave.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave.jl
@@ -93,8 +93,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
+++ b/test/tree_dgsem_3d/mhd_alfven_wave_mortar.jl
@@ -98,8 +98,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/mhd_ec.jl
+++ b/test/tree_dgsem_3d/mhd_ec.jl
@@ -93,8 +93,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -103,8 +103,7 @@ include("../test_macros.jl")
     TrixiCUDA.cuda_prolong2mortars!(u_gpu, mesh_gpu,
                                     TrixiCUDA.check_cache_mortars(cache_gpu),
                                     solver_gpu, cache_gpu)
-    Trixi.prolong2mortars!(cache, u, mesh, equations,
-                           solver.mortar, solver.surface_integral, solver)
+    Trixi.prolong2mortars!(cache, u, mesh, equations, solver.mortar, solver)
     @test_approx (cache_gpu.mortars.u_upper_left, cache.mortars.u_upper_left)
     @test_approx (cache_gpu.mortars.u_upper_right, cache.mortars.u_upper_right)
     @test_approx (cache_gpu.mortars.u_lower_left, cache.mortars.u_lower_left)


### PR DESCRIPTION
Replace #79 and fix #89.

This should require Julia 1.10.8 to avoid precompile warning and please add this to README file.