### PR TITLE
Add check for shared memory size per thread block

### DIFF
--- a/benchmark/mhd_shock_3d.jl
+++ b/benchmark/mhd_shock_3d.jl
@@ -13,8 +13,8 @@ initial_condition = initial_condition_weak_blast_wave
 surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
 volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
 
-basis = LobattoLegendreBasis(RealT, 3) # change back to 4 once shared memory check in on
-basis_gpu = LobattoLegendreBasisGPU(3, RealT) # change back to 4 once shared memory check in on
+basis = LobattoLegendreBasis(RealT, 4)
+basis_gpu = LobattoLegendreBasisGPU(4, RealT)
 
 indicator_sc = IndicatorHennemannGassner(equations, basis,
                                          alpha_max = 0.5f0,

--- a/src/auxiliary/auxiliary.jl
+++ b/src/auxiliary/auxiliary.jl
@@ -11,6 +11,7 @@ function init_device()
         # Get the device properties
         global MULTIPROCESSOR_COUNT = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
         global MAX_THREADS_PER_BLOCK = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK)
+        global MAX_SHARED_MEMORY_PER_BLOCK = CUDA.attribute(device, CUDA.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK)
     catch e
         # Handle the errors
         if e isa CUDA.CuError
@@ -23,5 +24,6 @@ function init_device()
         # Fall back to set default values
         global MULTIPROCESSOR_COUNT = 0
         global MAX_THREADS_PER_BLOCK = 0
+        global MAX_SHARED_MEMORY_PER_BLOCK = 0
     end
 end

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -934,20 +934,29 @@ end
 # Note that `volume_integral::VolumeIntegralPureLGLFiniteVolume` is currently experimental
 # in Trixi.jl and it is not implemented here.
 
+# The maximum number of threads per block is the dominant factor when choosing the optimization 
+# method. But note that there are other factors such as max register number per block and we will
+# enhance the checking mechanism in the future.
+
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
                                equations, volume_integral::VolumeIntegralWeakForm, dg::DGSEM,
                                cache_gpu, cache_cpu)
+    RealT = eltype(du)
+
     derivative_dhat = dg.basis.derivative_dhat
 
-    # The maximum number of threads per block is the dominant factor when choosing the optimization 
-    # method. However, there are other factors that may cause a launch failure, such as the maximum 
-    # shared memory per block. Here, we have omitted all other factors, but this should be enhanced 
-    # later for a safer kernel launch.
-
-    # TODO: More checks before the kernel launch
     thread_per_block = size(du, 1) * size(du, 2)
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequency use)
+        threads = (size(du, 1), size(du, 2), 1)
+        blocks = (1, 1, size(du, 3))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block flux_weak_form_kernel!(du, u,
+                                                                                         derivative_dhat,
+                                                                                         equations,
+                                                                                         flux)
+    else
         # How to optimize when size is large (less common use)?
         flux_arr = similar(u)
 
@@ -958,14 +967,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
         weak_form_kernel = @cuda launch=false weak_form_kernel!(du, derivative_dhat, flux_arr)
         weak_form_kernel(du, derivative_dhat, flux_arr;
                          kernel_configurator_3d(weak_form_kernel, size(du)...)...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(eltype(du))
-        threads = (size(du, 1), size(du, 2), 1)
-        blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size flux_weak_form_kernel!(du, u,
-                                                                                    derivative_dhat,
-                                                                                    equations,
-                                                                                    flux)
     end
 
     return nothing
@@ -981,7 +982,16 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
 
     thread_per_block = size(du, 2)
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequency use)
+        threads = (1, size(du, 2), 1)
+        blocks = (1, 1, size(du, 3))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
+                                                                                               derivative_split,
+                                                                                               equations,
+                                                                                               volume_flux)
+    else
         # How to optimize when size is large (less common use)?
         volume_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
 
@@ -995,14 +1005,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
                                                                             equations)
         volume_integral_kernel(du, derivative_split, volume_flux_arr, equations;
                                kernel_configurator_3d(volume_integral_kernel, size(du)...)...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
-        threads = (1, size(du, 2), 1)
-        blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
-                                                                                          derivative_split,
-                                                                                          equations,
-                                                                                          volume_flux)
     end
 
     return nothing
@@ -1018,7 +1020,17 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
 
     thread_per_block = size(du, 2)
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequency use)
+        threads = (1, size(du, 2), 1)
+        blocks = (1, 1, size(du, 3))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
+                                                                                               derivative_split,
+                                                                                               equations,
+                                                                                               symmetric_flux,
+                                                                                               nonconservative_flux)
+    else
         # How to optimize when size is large (less common use)?
         symmetric_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
         noncons_flux_arr = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 3))
@@ -1040,15 +1052,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
                                                                             noncons_flux_arr)
         volume_integral_kernel(du, derivative_split, symmetric_flux_arr, noncons_flux_arr;
                                kernel_configurator_3d(volume_integral_kernel, size(du)...)...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
-        threads = (1, size(du, 2), 1)
-        blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
-                                                                                          derivative_split,
-                                                                                          equations,
-                                                                                          symmetric_flux,
-                                                                                          nonconservative_flux)
     end
 
     return nothing
@@ -1072,7 +1075,19 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) +
+                       size(du, 1) * size(du, 2)) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequency use)
+        threads = (1, size(du, 2), 1)
+        blocks = (1, 1, size(du, 3))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
+                                                                                                    derivative_split,
+                                                                                                    inverse_weights,
+                                                                                                    equations,
+                                                                                                    volume_flux_dg,
+                                                                                                    volume_flux_fv)
+    else
         # TODO: Remove `fstar` from cache initialization
         fstar1_L = cache_gpu.fstar1_L
         fstar1_R = cache_gpu.fstar1_R
@@ -1098,17 +1113,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
         volume_integral_dgfv_kernel(du, alpha, derivative_split, inverse_weights, volume_flux_arr,
                                     fstar1_L, fstar1_R, atol, equations;
                                     kernel_configurator_3d(volume_integral_dgfv_kernel, size(du)...)...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) +
-                      size(du, 1) * size(du, 2)) * sizeof(RealT)
-        threads = (1, size(du, 2), 1)
-        blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
-                                                                                               derivative_split,
-                                                                                               inverse_weights,
-                                                                                               equations,
-                                                                                               volume_flux_dg,
-                                                                                               volume_flux_fv)
     end
 
     return nothing
@@ -1132,7 +1136,21 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) * 2 +
+                       size(du, 1) * size(du, 2)) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequency use)
+        threads = (1, size(du, 2), 1)
+        blocks = (1, 1, size(du, 3))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
+                                                                                                    derivative_split,
+                                                                                                    inverse_weights,
+                                                                                                    equations,
+                                                                                                    volume_flux_dg,
+                                                                                                    noncons_flux_dg,
+                                                                                                    volume_flux_fv,
+                                                                                                    noncons_flux_fv)
+    else
         # TODO: Remove `fstar` from cache initialization
         fstar1_L = cache_gpu.fstar1_L
         fstar1_R = cache_gpu.fstar1_R
@@ -1166,19 +1184,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
         volume_integral_dgfv_kernel(du, alpha, derivative_split, inverse_weights, volume_flux_arr,
                                     noncons_flux_arr, fstar1_L, fstar1_R, atol, equations;
                                     kernel_configurator_3d(volume_integral_dgfv_kernel, size(du)...)...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) * 2 +
-                      size(du, 1) * size(du, 2)) * sizeof(RealT)
-        threads = (1, size(du, 2), 1)
-        blocks = (1, 1, size(du, 3))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
-                                                                                               derivative_split,
-                                                                                               inverse_weights,
-                                                                                               equations,
-                                                                                               volume_flux_dg,
-                                                                                               noncons_flux_dg,
-                                                                                               volume_flux_fv,
-                                                                                               noncons_flux_fv)
     end
 
     return nothing

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -949,7 +949,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
     thread_per_block = size(du, 1) * size(du, 2)
     shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
     if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
-        # Go with the optimized version (frequency use)
+        # Go with the optimized version (frequent use)
         threads = (size(du, 1), size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
         @cuda threads=threads blocks=blocks shmem=shmem_per_block flux_weak_form_kernel!(du, u,
@@ -984,7 +984,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     thread_per_block = size(du, 2)
     shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
     if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
-        # Go with the optimized version (frequency use)
+        # Go with the optimized version (frequent use)
         threads = (1, size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
         @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
@@ -1022,7 +1022,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     thread_per_block = size(du, 2)
     shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)) * sizeof(RealT)
     if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
-        # Go with the optimized version (frequency use)
+        # Go with the optimized version (frequent use)
         threads = (1, size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
         @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
@@ -1078,7 +1078,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     shmem_per_block = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) +
                        size(du, 1) * size(du, 2)) * sizeof(RealT)
     if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
-        # Go with the optimized version (frequency use)
+        # Go with the optimized version (frequent use)
         threads = (1, size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
         @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
@@ -1139,7 +1139,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     shmem_per_block = (size(du, 2)^2 + size(du, 1) * (size(du, 2) + 1) * 2 +
                        size(du, 1) * size(du, 2)) * sizeof(RealT)
     if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
-        # Go with the optimized version (frequency use)
+        # Go with the optimized version (frequent use)
         threads = (1, size(du, 2), 1)
         blocks = (1, 1, size(du, 3))
         @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -2146,20 +2146,29 @@ end
 # Note that `volume_integral::VolumeIntegralPureLGLFiniteVolume` is currently experimental
 # in Trixi.jl and it is not implemented here.
 
+# The maximum number of threads per block is the dominant factor when choosing the optimization 
+# method. But note that there are other factors such as max register number per block and we will
+# enhance the checking mechanism in the future.
+
 # Pack kernels for calculating volume integrals
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, equations,
                                volume_integral::VolumeIntegralWeakForm, dg::DGSEM,
                                cache_gpu, cache_cpu)
+    RealT = eltype(du)
+
     derivative_dhat = dg.basis.derivative_dhat
 
-    # The maximum number of threads per block is the dominant factor when choosing the optimization 
-    # method. However, there are other factors that may cause a launch failure, such as the maximum 
-    # shared memory per block. Here, we have omitted all other factors, but this should be enhanced 
-    # later for a safer kernel launch.
-
-    # TODO: More checks before the kernel launch
     thread_per_block = size(du, 1) * size(du, 2)^3
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * 3 * size(du, 2)^3) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequent use) 
+        threads = (size(du, 1), size(du, 2)^3, 1)
+        blocks = (1, 1, size(du, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block flux_weak_form_kernel!(du, u,
+                                                                                         derivative_dhat,
+                                                                                         equations,
+                                                                                         flux)
+    else
         # How to optimize when size is large (less common use)?
         flux_arr1 = similar(u)
         flux_arr2 = similar(u)
@@ -2174,14 +2183,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, 
         weak_form_kernel(du, derivative_dhat, flux_arr1, flux_arr2, flux_arr3;
                          kernel_configurator_3d(weak_form_kernel, size(du, 1), size(du, 2)^3,
                                                 size(du, 5))...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * 3 * size(du, 2)^3) * sizeof(eltype(du))
-        threads = (size(du, 1), size(du, 2)^3, 1)
-        blocks = (1, 1, size(du, 5))
-        @cuda threads=threads blocks=blocks shmem=shmem_size flux_weak_form_kernel!(du, u,
-                                                                                    derivative_dhat,
-                                                                                    equations,
-                                                                                    flux)
     end
 
     return nothing
@@ -2197,7 +2198,16 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
 
     thread_per_block = size(du, 2)^3
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)^3) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequent use)
+        threads = (1, size(du, 2)^3, 1)
+        blocks = (1, 1, size(du, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
+                                                                                               derivative_split,
+                                                                                               equations,
+                                                                                               volume_flux)
+    else
         # How to optimize when size is large (less common use)?
         volume_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
                                           size(u, 2), size(u, 5))
@@ -2221,14 +2231,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
                                volume_flux_arr3, equations;
                                kernel_configurator_3d(volume_integral_kernel, size(du, 1),
                                                       size(du, 2)^3, size(du, 5))...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * size(du, 2)^3) * sizeof(RealT)
-        threads = (1, size(du, 2)^3, 1)
-        blocks = (1, 1, size(du, 5))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
-                                                                                          derivative_split,
-                                                                                          equations,
-                                                                                          volume_flux)
     end
 
     return nothing
@@ -2244,7 +2246,17 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     derivative_split = dg.basis.derivative_split
 
     thread_per_block = size(du, 2)^3
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(du, 2)^2 + size(du, 1) * size(du, 2)^3) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequent use)
+        threads = (1, size(du, 2)^3, 1)
+        blocks = (1, 1, size(du, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_kernel!(du, u,
+                                                                                               derivative_split,
+                                                                                               equations,
+                                                                                               symmetric_flux,
+                                                                                               nonconservative_flux)
+    else
         # How to optimize when size is large (less common use)?
         symmetric_flux_arr1 = CuArray{RealT}(undef, size(u, 1), size(u, 2), size(u, 2), size(u, 2),
                                              size(u, 2), size(u, 5))
@@ -2287,15 +2299,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
                                noncons_flux_arr3;
                                kernel_configurator_3d(volume_integral_kernel, size(du, 1),
                                                       size(du, 2)^3, size(du, 5))...)
-    else
-        shmem_size = (size(du, 2)^2 + size(du, 1) * size(du, 2)^3) * sizeof(RealT)
-        threads = (1, size(du, 2)^3, 1)
-        blocks = (1, 1, size(du, 5))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_kernel!(du, u,
-                                                                                          derivative_split,
-                                                                                          equations,
-                                                                                          symmetric_flux,
-                                                                                          nonconservative_flux)
     end
 
     return nothing
@@ -2319,7 +2322,19 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)^3
-    if thread_per_block > MAX_THREADS_PER_BLOCK
+    shmem_per_block = (size(u, 2)^2 + size(u, 1) * size(u, 2)^2 * (size(u, 2) + 1) * 3 +
+                       size(u, 1) * size(u, 2)^3) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequent use)
+        threads = (1, size(u, 2)^3, 1)
+        blocks = (1, 1, size(u, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
+                                                                                                    derivative_split,
+                                                                                                    inverse_weights,
+                                                                                                    equations,
+                                                                                                    volume_flux_dg,
+                                                                                                    volume_flux_fv)
+    else
         # TODO: Remove `fstar` from cache initialization
         fstar1_L = cache_gpu.fstar1_L
         fstar1_R = cache_gpu.fstar1_R
@@ -2367,17 +2382,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
                                     fstar2_L, fstar2_R, fstar3_L, fstar3_R, atol, equations;
                                     kernel_configurator_3d(volume_integral_dgfv_kernel, size(du, 1),
                                                            size(du, 2)^3, size(du, 5))...)
-    else
-        shmem_size = (size(u, 2)^2 + size(u, 1) * size(u, 2)^2 * (size(u, 2) + 1) * 3 +
-                      size(u, 1) * size(u, 2)^3) * sizeof(RealT)
-        threads = (1, size(u, 2)^3, 1)
-        blocks = (1, 1, size(u, 5))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
-                                                                                               derivative_split,
-                                                                                               inverse_weights,
-                                                                                               equations,
-                                                                                               volume_flux_dg,
-                                                                                               volume_flux_fv)
     end
 
     return nothing
@@ -2401,7 +2405,21 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     atol = max(100 * eps(RealT), eps(RealT)^convert(RealT, 0.75f0))
 
     thread_per_block = size(du, 2)^3
-    if thread_per_block > MAX_THREADS_PER_BLOCK # add check for shared memory
+    shmem_per_block = (size(u, 2)^2 + size(u, 1) * size(u, 2)^2 * (size(u, 2) + 1) * 6 +
+                       size(u, 1) * size(u, 2)^3) * sizeof(RealT)
+    if thread_per_block <= MAX_THREADS_PER_BLOCK && shmem_per_block <= MAX_SHARED_MEMORY_PER_BLOCK
+        # Go with the optimized version (frequent use)
+        threads = (1, size(u, 2)^3, 1)
+        blocks = (1, 1, size(u, 5))
+        @cuda threads=threads blocks=blocks shmem=shmem_per_block volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
+                                                                                                    derivative_split,
+                                                                                                    inverse_weights,
+                                                                                                    equations,
+                                                                                                    volume_flux_dg,
+                                                                                                    noncons_flux_dg,
+                                                                                                    volume_flux_fv,
+                                                                                                    noncons_flux_fv)
+    else
         # TODO: Remove `fstar` from cache initialization
         fstar1_L = cache_gpu.fstar1_L
         fstar1_R = cache_gpu.fstar1_R
@@ -2466,19 +2484,6 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
                                     fstar2_L, fstar2_R, fstar3_L, fstar3_R, atol, equations;
                                     kernel_configurator_3d(volume_integral_dgfv_kernel, size(du, 1),
                                                            size(du, 2)^3, size(du, 5))...)
-    else
-        shmem_size = (size(u, 2)^2 + size(u, 1) * size(u, 2)^2 * (size(u, 2) + 1) * 6 +
-                      size(u, 1) * size(u, 2)^3) * sizeof(RealT)
-        threads = (1, size(u, 2)^3, 1)
-        blocks = (1, 1, size(u, 5))
-        @cuda threads=threads blocks=blocks shmem=shmem_size volume_flux_integral_dgfv_kernel!(du, u, alpha, atol,
-                                                                                               derivative_split,
-                                                                                               inverse_weights,
-                                                                                               equations,
-                                                                                               volume_flux_dg,
-                                                                                               noncons_flux_dg,
-                                                                                               volume_flux_fv,
-                                                                                               noncons_flux_fv)
     end
 
     return nothing

--- a/test/tree_dgsem_3d/mhd_shock.jl
+++ b/test/tree_dgsem_3d/mhd_shock.jl
@@ -13,8 +13,8 @@ include("../test_macros.jl")
     surface_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
     volume_flux = (flux_hindenlang_gassner, flux_nonconservative_powell)
 
-    basis = LobattoLegendreBasis(3) # change back to 4 once shared memory check in on
-    basis_gpu = LobattoLegendreBasisGPU(3) # change back to 4 once shared memory check in on
+    basis = LobattoLegendreBasis(4)
+    basis_gpu = LobattoLegendreBasisGPU(4)
 
     indicator_sc = IndicatorHennemannGassner(equations, basis,
                                              alpha_max = 0.5,


### PR DESCRIPTION
If the shared memory size per thread block is larger than the hardware configuration, the kernel will launch with failure. So besides the check for thread number per block, we add one more check for shared memory.