### PR TITLE
Bump crate-ci/typos from 1.31.1 to 1.31.2 

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Typo and Spelling Check
-        uses: crate-ci/typos@v1.31.1
+        uses: crate-ci/typos@v1.31.2
         with:
           config: .typos.toml # Specify the custom configuration file


### PR DESCRIPTION
Replace #149 to retrigger buildkite tests.