### PR TITLE
Add documentations for all GPU kernels 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0-DEV"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 
 [compat]
 Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 
 [compat]
 Documenter = "1"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -8,3 +8,11 @@ TrixiCUDA.DGSEMGPU
 TrixiCUDA.SemidiscretizationHyperbolicGPU
 TrixiCUDA.semidiscretizeGPU
 ```
+
+# GPU Kernels in Semidiscretizations
+
+All GPU kernels are encapsulated within the semidiscretization (i.e., `rhs_gpu!` function).
+
+```@docs
+TrixiCUDA.cuda_volume_integral!
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,6 +1,6 @@
 # Public APIs
 
-All APIs currently default to double precision (`Float64`). Support for single precision (`Float32`) is considered experimental, as it has not yet undergone comprehensive testing and validation.
+All APIs currently default to double precision (`Float64`). Single precision (`Float32`) is supported but still experimental, as it still needs testing to avoid type promotion. 
 
 ```@docs
 TrixiCUDA.LobattoLegendreBasisGPU
@@ -9,7 +9,10 @@ TrixiCUDA.SemidiscretizationHyperbolicGPU
 TrixiCUDA.semidiscretizeGPU
 ```
 
-# GPU Kernels in Semidiscretizations
+# Semidiscretization
+
+
+# GPU Kernels in Semidiscretization
 
 All GPU kernels are encapsulated within the semidiscretization (i.e., `rhs_gpu!` function).
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -9,13 +9,21 @@ TrixiCUDA.SemidiscretizationHyperbolicGPU
 TrixiCUDA.semidiscretizeGPU
 ```
 
-# Semidiscretization
+# Private APIs
 
+## Semidiscretization
+```@docs
+TrixiCUDA.rhs_gpu!
+```
 
-# GPU Kernels in Semidiscretization
-
-All GPU kernels are encapsulated within the semidiscretization (i.e., `rhs_gpu!` function).
-
+## GPU Kernels in Semidiscretization
 ```@docs
 TrixiCUDA.cuda_volume_integral!
+TrixiCUDA.cuda_prolong2interfaces!
+TrixiCUDA.cuda_interface_flux!
+TrixiCUDA.cuda_prolong2boundaries!
+TrixiCUDA.cuda_boundary_flux!
+TrixiCUDA.cuda_surface_integral!
+TrixiCUDA.cuda_jacobian!
+TrixiCUDA.cuda_sources!
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -23,6 +23,8 @@ TrixiCUDA.cuda_prolong2interfaces!
 TrixiCUDA.cuda_interface_flux!
 TrixiCUDA.cuda_prolong2boundaries!
 TrixiCUDA.cuda_boundary_flux!
+TrixiCUDA.cuda_prolong2mortars!
+TrixiCUDA.cuda_mortar_flux!
 TrixiCUDA.cuda_surface_integral!
 TrixiCUDA.cuda_jacobian!
 TrixiCUDA.cuda_sources!

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -4,7 +4,6 @@
 # Adapt a general polynomial degree function since `DGSEMGPU` gives a `DG` type
 @inline polydeg(dg::DG) = polydeg(dg.basis)
 
-#########################################################################################
 # Based on benchmarks, using `reshape` is faster than `unsafe_wrap` for GPU arrays (why?),
 # but currently we are not sure about if reshape can be used for later `resize!` operations.
 # But now we don't take AMR into account, so we can use `reshape` for now.
@@ -36,7 +35,6 @@ end
 #                             dg::FDSBP, cache)
 #     @error("TrixiCUDA.jl does not support FDSBP yet.")
 # end
-#########################################################################################
 
 # FIXME: This is a temporary workaround to avoid scalar indexing issue.
 function volume_jacobian_tmp(element, mesh::TreeMesh, cache)
@@ -159,4 +157,170 @@ function compute_coefficients_gpu(u, func, t, mesh::AbstractMesh{3}, equations, 
                                                        size(u, 5))...)
 
     return u
+end
+
+# Generic GPU kerenls definitions and docs. 
+# More specific functoin definitions and comments are in dg_1d.jl, dg_2d.jl, dg_3d.jl files.
+"""
+    cuda_volume_integral!(du, u, mesh, nonconservative_terms, equations, volume_integral, dg,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU. This routine dispatches to the appropriate kernel 
+implementation depending on `volume_integral` and whether `nonconservative_terms` are present.
+
+Variants include:
+  - [`VolumeIntegralWeakForm`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralWeakForm) 
+    (classical weak form);
+  - [`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing) 
+    (split form using symmetric two-point flux) with and without non-conservative terms;
+  - [`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG) 
+    (hybrid DG–FV scheme using an indicator) with and without non-conservative terms.
+
+Writes into `du` in place. Returns `nothing`.
+"""
+function cuda_volume_integral!(du, u, mesh, nonconservative_terms, equations, volume_integral, dg,
+                               cache_gpu, cache_cpu)
+end
+
+"""
+    cuda_prolong2interfaces!(u, mesh, equations, cache)
+
+Prolong the solution from element interiors to interior interfaces on the GPU.
+This prepares trace data used by interface flux kernels.
+
+Writes interface traces to `cache.interfaces.u`. Returns `nothing`.
+"""
+function cuda_prolong2interfaces!(u, mesh, equations, cache) end
+
+"""
+    cuda_interface_flux!(mesh, nonconservative_terms, equations, dg, cache)
+
+Compute numerical fluxes on interior interfaces on the GPU, with or without
+non-conservative terms.
+
+If `nonconservative_terms` is `False`, use the conservative surface flux from 
+`dg.surface_integral.surface_flux`; if `nonconservative_terms` is `True`, take 
+both the conservative and non-conservative fluxes from it and accumulate both.
+
+Writes interface fluxes to `cache.elements.surface_flux_values`. Returns `nothing`.
+"""
+function cuda_interface_flux!(mesh, nonconservative_terms, equations, dg, cache) end
+
+"""
+    cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache)
+
+Prolong the solution from element interiors to physical boundaries on the GPU.
+For periodic boundaries this is a no-op method.
+
+Variants include:
+  - [`BoundaryConditionPeriodic`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.boundary_condition_periodic) 
+    (no operation for periodic boundaries);
+  - `NamedTuple` (boundary conditions provided as a `NamedTuple`).
+
+Writes boundary traces to `cache.boundaries.u` when applicable. Returns `nothing`.
+"""
+function cuda_prolong2boundaries!(u, mesh, boundary_conditions, equations, cache) end
+
+"""
+    cuda_boundary_flux!(t, mesh, boundary_conditions, nonconservative_terms, equations, dg, 
+                        cache)
+
+Compute numerical fluxes on physical boundaries on the GPU at time `t`. The
+flux implementation is taken from `dg.surface_integral.surface_flux` and may
+handle non-conservative contributions when requested. For periodic boundaries
+this is a no-op method.
+
+Variants include:
+  - [`BoundaryConditionPeriodic`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.boundary_condition_periodic) 
+    (no operation for periodic boundaries);
+  - `NamedTuple` (boundary conditions provided as a `NamedTuple`) with and without non-conservative terms.
+
+Writes boundary flux contributions to `cache.elements.surface_flux_values`. 
+Returns `nothing`.
+"""
+function cuda_boundary_flux!(t, mesh, boundary_conditions, nonconservative_terms, equations,
+                             dg, cache)
+end
+
+"""
+    cuda_prolong2mortars!(u, mesh, cache_mortars, dg, cache)
+
+Prolong the solution from element faces to mortar interfaces on the GPU for 2D/3D problems.
+
+When `cache_mortars` is `True`, fills the mortar trace buffers in `cache.mortars` using the
+appropriate transfer operators from `dg.mortar`. When `cache_mortars` is `False`, this is a no-op.
+
+Writes mortar trace buffers to `cache.mortars` (layout depends on dimension).
+Returns `nothing`.
+"""
+function cuda_prolong2mortars!(u, mesh, cache_mortars, dg, cache) end
+
+"""
+    cuda_mortar_flux!(mesh, cache_mortars, nonconservative_terms, equations, dg, cache)
+
+Compute numerical fluxes on mortar interfaces on the GPU for 2D/3D problems.
+
+Uses `dg.surface_integral.surface_flux`; when `nonconservative_terms` is `True`,
+also includes the corresponding non-conservative partner flux. Contributions are
+assembled back to the element side via the reverse mortar maps. When
+`cache_mortars` is `False`, this is a no-op.
+
+Writes to `cache.elements.surface_flux_values` (via temporary mortar buffers).
+Returns `nothing`.
+"""
+function cuda_mortar_flux!(mesh, cache_mortars, nonconservative_terms, equations, dg, cache) end
+
+"""
+    cuda_surface_integral!(du, mesh, equations, dg, cache)
+
+Accumulate interface and boundary fluxes into the element residual on the GPU
+using the DG surface integral with boundary interpolation weights.
+
+Updates `du` in place. Returns `nothing`.
+"""
+function cuda_surface_integral!(du, mesh, equations, dg, cache) end
+
+"""
+    cuda_jacobian!(du, mesh, equations, cache)
+
+Apply the inverse Jacobian and geometric scaling on the GPU to map reference
+operators to physical space as part of the semidiscretization.
+
+Updates `du` in place. Returns `nothing`.
+"""
+function cuda_jacobian!(du, mesh, equations, cache) end
+
+"""
+    cuda_sources!(du, u, t, source_terms, equations, cache)
+
+Evaluate and add source terms on the GPU at time `t`. When `source_terms` is not presented,
+this method is a no-op.
+
+Updates `du` in place. Returns `nothing`.
+"""
+function cuda_sources!(du, u, t, source_terms, equations, cache) end
+
+"""
+    rhs_gpu!(du, u, t, mesh, equations, boundary_conditions, source_terms, dg, cache_gpu, 
+             cache_cpu)
+
+Assemble the semidiscrete right-hand side on the GPU. This routine orchestrates
+CUDA kernels for: volume integrals; prolongation to interior interfaces (and, in
+2D/3D, to mortars with the associated mortar fluxes); interior-interface fluxes;
+boundary prolongation and boundary fluxes; surface accumulation; inverse-Jacobian
+scaling; and source terms.
+
+Variants:
+  - [`TreeMesh{1}`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.TreeMesh): 
+    no mortar stages.
+  - [`TreeMesh{2}`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.TreeMesh) / 
+    [`TreeMesh{3}`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.TreeMesh): 
+    includes [`cuda_prolong2mortars!`](@ref) and [`cuda_mortar_flux!`](@ref).
+
+Effects: writes results into `du` in place. Return value: `nothing`.
+
+Notes: `reset_du!(du)` is fused into the first kernel and therefore not called separately.
+"""
+function rhs_gpu!(du, u, t, mesh, equations, boundary_conditions, source_terms, dg,
+                  cache_gpu, cache_cpu)
 end

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -159,8 +159,8 @@ function compute_coefficients_gpu(u, func, t, mesh::AbstractMesh{3}, equations, 
     return u
 end
 
-# Generic GPU kerenls definitions and docs. 
-# More specific functoin definitions and comments are in dg_1d.jl, dg_2d.jl, dg_3d.jl files.
+# Generic GPU kernels definitions and docs. 
+# More specific function definitions and comments are in dg_1d.jl, dg_2d.jl, dg_3d.jl files.
 """
     cuda_volume_integral!(du, u, mesh, nonconservative_terms, equations, volume_integral, dg,
                           cache_gpu, cache_cpu)

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -13,18 +13,11 @@ include("dg_1d_kernel.jl")
 # method. But note that there are other factors such as max register number per block and we will
 # enhance the checking mechanism in the future.
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms, equations, 
-                          volume_integral::VolumeIntegralWeakForm, dg::DG, 
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 1D problems using the classical weak form 
-volume operator ([`VolumeIntegralWeakForm`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralWeakForm)).
-"""
-
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms, equations,
-                               volume_integral::VolumeIntegralWeakForm, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 1D problems using the classical 
+# weak form volume operator.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
+                               equations, volume_integral::VolumeIntegralWeakForm,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     derivative_dhat = dg.basis.derivative_dhat
@@ -55,18 +48,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms, 
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations, 
-                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG, 
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 1D problems using the flux differencing volume operator 
-([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
-with non-conservative terms disabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 1D problems using the flux differencing 
+# volume operator with non-conservative terms disabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -101,18 +87,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 1D problems using the flux differencing volume operator
-([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
-with non-conservative terms enabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 1D problems using the flux differencing 
+# volume operator with non-conservative terms enabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     symmetric_flux, nonconservative_flux = dg.volume_integral.volume_flux
@@ -156,18 +135,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations, 
-                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 1D problems using the hybrid DG–FV shock capturing operator
-([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
-with non-conservative terms disabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 1D problems using the hybrid DG 
+# finite volume shock capturing operator with non-conservative terms disabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, volume_flux_fv = dg.volume_integral.volume_flux_dg,
@@ -225,18 +197,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 1D problems using the hybrid DG–FV shock capturing operator
-([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
-with non-conservative terms enabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 1D problems using the hybrid DG finite volume 
+# shock capturing operator with non-conservative terms enabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, noncons_flux_dg = dg.volume_integral.volume_flux_dg
@@ -304,11 +269,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
-
-Prolong the solution from element interiors to inter-element interfaces on the GPU for 1D problems.
-"""
+# Prolong the solution from element interiors to interelement interfaces on the GPU for 1D problems.
 function cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
     neighbor_ids = cache.interfaces.neighbor_ids
     interfaces_u = cache.interfaces.u
@@ -323,12 +284,7 @@ function cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
     return nothing
 end
 
-"""
-    cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, equations, dg::DG,
-                         cache)
-
-Compute interface fluxes on the GPU for 1D problems with non-conservative terms disabled.
-"""
+# Compute interface fluxes on the GPU for 1D problems with non-conservative terms disabled.
 function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -356,12 +312,7 @@ function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, e
     return nothing
 end
 
-"""
-    cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, equations, dg::DG,
-                         cache)
-
-Compute interface fluxes on the GPU for 1D problems with non-conservative terms enabled.
-"""
+# Compute interface fluxes on the GPU for 1D problems with non-conservative terms enabled.
 function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -402,23 +353,13 @@ function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, eq
     return nothing
 end
 
-"""
-    cuda_prolong2boundaries!(u, mesh::TreeMesh{1},
-                             boundary_condition::BoundaryConditionPeriodic, equations, cache)
-
-Dummy function; no operation is required for periodic boundary conditions.
-"""
+# No operation for periodic boundary conditions.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{1},
                                   boundary_condition::BoundaryConditionPeriodic, equations, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-"""
-    cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::NamedTuple, equations,
-                             cache)
-
-Prolong the solution from element interiors to boundaries on the GPU for 1D problems.
-"""
+# Prolong the solution from element interiors to boundaries on the GPU for 1D problems.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::NamedTuple, equations,
                                   cache)
     neighbor_ids = cache.boundaries.neighbor_ids
@@ -436,23 +377,13 @@ function cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::Nam
     return nothing
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_condition::BoundaryConditionPeriodic,
-                        nonconservative_terms, equations, dg::DG, cache)
-
-Dummy function; no operation is required for periodic boundary conditions.
-"""
+# No operation for periodic boundary conditions.
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_condition::BoundaryConditionPeriodic,
                              nonconservative_terms, equations, dg::DG, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
-                        nonconservative_terms::False, equations, dg::DG, cache)
-
-Compute boundary fluxes on the GPU for 1D problems with non-conservative terms disabled.
-"""
+# Compute boundary fluxes on the GPU for 1D problems with non-conservative terms disabled.
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
                              nonconservative_terms::False, equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -495,12 +426,7 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTup
     return nothing
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
-                        nonconservative_terms::True, equations, dg::DG, cache)
-
-Compute boundary fluxes on the GPU for 1D problems with non-conservative terms enabled.
-"""
+# Compute boundary fluxes on the GPU for 1D problems with non-conservative terms enabled.
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
                              nonconservative_terms::True, equations, dg::DG, cache)
     # Contain both conservative and nonconservative fluxes
@@ -546,11 +472,7 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTup
     return nothing
 end
 
-"""
-    cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
-
-Accumulate surface contributions into the DG scheme on the GPU for 1D problems.
-"""
+# Accumulate surface contributions into the DG scheme on the GPU for 1D problems.
 function cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
     factor_arr = CuArray([
                              dg.basis.boundary_interpolation[1, 1],
@@ -567,11 +489,7 @@ function cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
     return nothing
 end
 
-"""
-    cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
-
-Apply the inverse Jacobian transformation on the GPU for 1D problems.
-"""
+# Apply the inverse Jacobian transformation on the GPU for 1D problems.
 function cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
     inverse_jacobian = cache.elements.inverse_jacobian
 
@@ -582,20 +500,12 @@ function cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
     return nothing
 end
 
-"""
-    cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{1}, cache)
-
-Dummy function; no operation is required when no source terms are present.
-"""
+# No operation when no source terms are present.
 function cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{1}, cache)
     return nothing
 end
 
-"""
-    cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, cache)
-
-Evaluate and add source terms on the GPU for 1D problems at the current time and node coordinates.
-"""
+# Evaluate and add source terms on the GPU for 1D problems at the current time and node coordinates.
 function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, cache)
     node_coordinates = cache.elements.node_coordinates
 
@@ -607,16 +517,9 @@ function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, 
     return nothing
 end
 
-# Put everything together into a single function.
-# See also `rhs!` function in Trixi.jl
-"""
-    rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
-             source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
-
-Assemble the semidiscrete right-hand side on the GPU for 1D problems by invoking, in order,
-the DG volume term, interface and boundary fluxes, surface accumulation, Jacobian transformation,
-and source terms.
-"""
+# Assemble the semidiscrete right-hand side on the GPU for 1D problems by invoking the 
+# DG volume term, interface and boundary fluxes, surface accumulation, Jacobian transformation, 
+# and source terms.
 function rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
                   source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -14,6 +14,15 @@ include("dg_1d_kernel.jl")
 # enhance the checking mechanism in the future.
 
 # Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
+                          equations, volume_integral::VolumeIntegralWeakForm,
+                          dg::DG, cache_gpu, cache_cpu)
+
+Compute the volume integral of the PDE system using a GPU kernel for 1D problems with a weak-form DG discretization.
+
+This function dispatches a CUDA kernel to compute the volume term
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
                                equations, volume_integral::VolumeIntegralWeakForm, dg::DG,
                                cache_gpu, cache_cpu)

--- a/src/solvers/dg_1d.jl
+++ b/src/solvers/dg_1d.jl
@@ -13,18 +13,17 @@ include("dg_1d_kernel.jl")
 # method. But note that there are other factors such as max register number per block and we will
 # enhance the checking mechanism in the future.
 
-# Pack kernels for calculating volume integrals
 """
-    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
-                          equations, volume_integral::VolumeIntegralWeakForm,
-                          dg::DG, cache_gpu, cache_cpu)
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms, equations, 
+                          volume_integral::VolumeIntegralWeakForm, dg::DG, 
+                          cache_gpu, cache_cpu)
 
-Compute the volume integral of the PDE system using a GPU kernel for 1D problems with a weak-form DG discretization.
-
-This function dispatches a CUDA kernel to compute the volume term
+Compute the DG volume term on the GPU for 1D problems using the classical weak form 
+volume operator ([`VolumeIntegralWeakForm`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralWeakForm)).
 """
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
-                               equations, volume_integral::VolumeIntegralWeakForm, dg::DG,
+
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms, equations,
+                               volume_integral::VolumeIntegralWeakForm, dg::DG,
                                cache_gpu, cache_cpu)
     RealT = eltype(du)
 
@@ -56,10 +55,18 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms,
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
-function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False,
-                               equations, volume_integral::VolumeIntegralFluxDifferencing,
-                               dg::DG, cache_gpu, cache_cpu)
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations, 
+                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG, 
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 1D problems using the flux differencing volume operator 
+([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
+with non-conservative terms disabled.
+"""
+function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations,
+                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
+                               cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -94,7 +101,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
+                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 1D problems using the flux differencing volume operator
+([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
+with non-conservative terms enabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
                                cache_gpu, cache_cpu)
@@ -141,7 +156,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations, 
+                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 1D problems using the hybrid DG–FV shock capturing operator
+([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
+with non-conservative terms disabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -202,7 +225,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
+                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 1D problems using the hybrid DG–FV shock capturing operator
+([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
+with non-conservative terms enabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -273,7 +304,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{1}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for prolonging solution to interfaces
+"""
+    cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
+
+Prolong the solution from element interiors to inter-element interfaces on the GPU for 1D problems.
+"""
 function cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
     neighbor_ids = cache.interfaces.neighbor_ids
     interfaces_u = cache.interfaces.u
@@ -288,7 +323,12 @@ function cuda_prolong2interfaces!(u, mesh::TreeMesh{1}, equations, cache)
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+"""
+    cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, equations, dg::DG,
+                         cache)
+
+Compute interface fluxes on the GPU for 1D problems with non-conservative terms disabled.
+"""
 function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -316,7 +356,12 @@ function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::False, e
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+"""
+    cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, equations, dg::DG,
+                         cache)
+
+Compute interface fluxes on the GPU for 1D problems with non-conservative terms enabled.
+"""
 function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -357,13 +402,23 @@ function cuda_interface_flux!(mesh::TreeMesh{1}, nonconservative_terms::True, eq
     return nothing
 end
 
-# Dummy function for asserting boundaries
+"""
+    cuda_prolong2boundaries!(u, mesh::TreeMesh{1},
+                             boundary_condition::BoundaryConditionPeriodic, equations, cache)
+
+Dummy function; no operation is required for periodic boundary conditions.
+"""
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{1},
                                   boundary_condition::BoundaryConditionPeriodic, equations, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for prolonging solution to boundaries
+"""
+    cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::NamedTuple, equations,
+                             cache)
+
+Prolong the solution from element interiors to boundaries on the GPU for 1D problems.
+"""
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::NamedTuple, equations,
                                   cache)
     neighbor_ids = cache.boundaries.neighbor_ids
@@ -381,13 +436,23 @@ function cuda_prolong2boundaries!(u, mesh::TreeMesh{1}, boundary_conditions::Nam
     return nothing
 end
 
-# Dummy function for asserting boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_condition::BoundaryConditionPeriodic,
+                        nonconservative_terms, equations, dg::DG, cache)
+
+Dummy function; no operation is required for periodic boundary conditions.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_condition::BoundaryConditionPeriodic,
                              nonconservative_terms, equations, dg::DG, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for calculating boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
+                        nonconservative_terms::False, equations, dg::DG, cache)
+
+Compute boundary fluxes on the GPU for 1D problems with non-conservative terms disabled.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
                              nonconservative_terms::False, equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -430,7 +495,12 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTup
     return nothing
 end
 
-# Pack kernels for calculating boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
+                        nonconservative_terms::True, equations, dg::DG, cache)
+
+Compute boundary fluxes on the GPU for 1D problems with non-conservative terms enabled.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTuple,
                              nonconservative_terms::True, equations, dg::DG, cache)
     # Contain both conservative and nonconservative fluxes
@@ -476,7 +546,11 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{1}, boundary_conditions::NamedTup
     return nothing
 end
 
-# Pack kernels for calculating surface integrals
+"""
+    cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
+
+Accumulate surface contributions into the DG scheme on the GPU for 1D problems.
+"""
 function cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
     factor_arr = CuArray([
                              dg.basis.boundary_interpolation[1, 1],
@@ -493,7 +567,11 @@ function cuda_surface_integral!(du, mesh::TreeMesh{1}, equations, dg::DG, cache)
     return nothing
 end
 
-# Pack kernels for applying Jacobian to reference element
+"""
+    cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
+
+Apply the inverse Jacobian transformation on the GPU for 1D problems.
+"""
 function cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
     inverse_jacobian = cache.elements.inverse_jacobian
 
@@ -504,12 +582,20 @@ function cuda_jacobian!(du, mesh::TreeMesh{1}, equations, cache)
     return nothing
 end
 
-# Dummy function returning nothing             
+"""
+    cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{1}, cache)
+
+Dummy function; no operation is required when no source terms are present.
+"""
 function cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{1}, cache)
     return nothing
 end
 
-# Pack kernels for calculating source terms 
+"""
+    cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, cache)
+
+Evaluate and add source terms on the GPU for 1D problems at the current time and node coordinates.
+"""
 function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, cache)
     node_coordinates = cache.elements.node_coordinates
 
@@ -522,8 +608,15 @@ function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{1}, 
 end
 
 # Put everything together into a single function.
-
 # See also `rhs!` function in Trixi.jl
+"""
+    rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
+             source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
+
+Assemble the semidiscrete right-hand side on the GPU for 1D problems by invoking, in order,
+the DG volume term, interface and boundary fluxes, surface accumulation, Jacobian transformation,
+and source terms.
+"""
 function rhs_gpu!(du, u, t, mesh::TreeMesh{1}, equations, boundary_conditions,
                   source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -13,17 +13,11 @@ include("dg_2d_kernel.jl")
 # method. But note that there are other factors such as max register number per block and we will
 # enhance the checking mechanism in the future.
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, equations,
-                          volume_integral::VolumeIntegralWeakForm, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 2D problems using the classical weak form 
-volume operator ([`VolumeIntegralWeakForm`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralWeakForm)).
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, equations,
-                               volume_integral::VolumeIntegralWeakForm, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 2D problems using the classical 
+# weak form volume operator.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms,
+                               equations, volume_integral::VolumeIntegralWeakForm,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     derivative_dhat = dg.basis.derivative_dhat
@@ -57,18 +51,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, 
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 2D problems using the flux differencing volume operator 
-([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
-with non-conservative terms disabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 2D problems using the flux differencing 
+# volume operator with non-conservative terms disabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -107,18 +94,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 2D problems using the flux differencing volume operator 
-([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
-with non-conservative terms enabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 2D problems using the flux differencing 
+# volume operator with non-conservative terms enabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     symmetric_flux, nonconservative_flux = dg.volume_integral.volume_flux
@@ -174,18 +154,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 2D problems using the hybrid DG–FV shock capturing operator
-([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
-with non-conservative terms disabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 2D problems using the hybrid DG finite volume 
+# shock capturing operator with non-conservative terms disabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, volume_flux_fv = dg.volume_integral.volume_flux_dg,
@@ -255,18 +228,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                          cache_gpu, cache_cpu)
-
-Compute the DG volume term on the GPU for 2D problems using the hybrid DG–FV shock capturing operator
-([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
-with non-conservative terms enabled.
-"""
-function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+# Compute the DG volume term on the GPU for 2D problems using the hybrid DG finite volume 
+# shock capturing operator with non-conservative terms enabled.
+function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, noncons_flux_dg = dg.volume_integral.volume_flux_dg
@@ -351,11 +317,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-"""
-    cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
-
-Prolong the solution from element interiors to inter-element interfaces on the GPU for 2D problems.
-"""
+# Prolong the solution from element interiors to interelement interfaces on the GPU for 2D problems.
 function cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
     neighbor_ids = cache.interfaces.neighbor_ids
     orientations = cache.interfaces.orientations
@@ -373,12 +335,7 @@ function cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
     return nothing
 end
 
-"""
-    cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, equations, dg::DG,
-                         cache)
-
-Compute interface fluxes on the GPU for 2D problems with non-conservative terms disabled.
-"""
+# Compute interface fluxes on the GPU for 2D problems with non-conservative terms disabled.
 function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -412,12 +369,7 @@ function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, e
     return nothing
 end
 
-"""
-    cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, equations, dg::DG,
-                         cache)
-
-Compute interface fluxes on the GPU for 2D problems with non-conservative terms enabled.
-"""
+# Compute interface fluxes on the GPU for 2D problems with non-conservative terms enabled.
 function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -463,23 +415,13 @@ function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, eq
     return nothing
 end
 
-"""
-    cuda_prolong2boundaries!(u, mesh::TreeMesh{2},
-                             boundary_condition::BoundaryConditionPeriodic, equations, cache)
-
-Dummy function; no operation is required for periodic boundary conditions.
-"""
+# No operation for periodic boundary conditions.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{2},
                                   boundary_condition::BoundaryConditionPeriodic, equations, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-"""
-    cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::NamedTuple, equations,
-                             cache)
-
-Prolong the solution from element interiors to boundaries on the GPU for 2D problems.
-"""
+# Prolong the solution from element interiors to boundaries on the GPU for 2D problems.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::NamedTuple, equations,
                                   cache)
     neighbor_ids = cache.boundaries.neighbor_ids
@@ -501,23 +443,13 @@ function cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::Nam
     return nothing
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_condition::BoundaryConditionPeriodic,
-                        nonconservative_terms, equations, dg::DG, cache)
-
-Dummy function; no operation is required for periodic boundary conditions.
-"""
+# No operation for periodic boundary conditions.
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_condition::BoundaryConditionPeriodic,
                              nonconservative_terms, equations, dg::DG, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
-                        nonconservative_terms::False, equations, dg::DG, cache)
-
-Compute boundary fluxes on the GPU for 2D problems with non-conservative terms disabled.
-"""
+# Compute boundary fluxes on the GPU for 2D problems with non-conservative terms disabled.
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
                              nonconservative_terms::False, equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -561,12 +493,7 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTup
     return nothing
 end
 
-"""
-    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
-                        nonconservative_terms::True, equations, dg::DG, cache)
-
-Compute boundary fluxes on the GPU for 2D problems with non-conservative terms enabled.
-"""
+# Compute boundary fluxes on the GPU for 2D problems with non-conservative terms enabled.
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
                              nonconservative_terms::True, equations, dg::DG, cache)
     # Contain both conservative and nonconservative fluxes
@@ -613,20 +540,12 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTup
     return nothing
 end
 
-"""
-    cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::False, dg::DG, cache)
-
-No operation. This specialization is used when the semidiscretization does not allocate mortar data.
-"""
+# No operation when mortar data are not allocated.
 function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::False, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-"""
-    cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG, cache)
-
-Prolong the solution from element faces to mortar interfaces on the GPU for 2D problems。
-"""
+# Prolong the solution from element faces to mortar interfaces on the GPU for 2D problems.
 function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG, cache)
     neighbor_ids = cache.mortars.neighbor_ids
     large_sides = cache.mortars.large_sides
@@ -666,23 +585,13 @@ function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG
     return nothing
 end
 
-"""
-    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::False, nonconservative_terms,
-                      equations, dg::DG, cache)
-
-No operation. This specialization is used when mortar data are not present.
-"""
+# No operation when mortar data are not present.
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::False, nonconservative_terms,
                            equations, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-"""
-    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::False,
-                      equations, dg::DG, cache)
-
-Compute mortar fluxes on the GPU for 2D problems with non-conservative terms disabled.
-"""
+# Compute mortar fluxes on the GPU for 2D problems with non-conservative terms disabled.
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::False,
                            equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -739,12 +648,7 @@ function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservati
     return nothing
 end
 
-"""
-    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::True,
-                      equations, dg::DG, cache)
-
-Compute mortar fluxes on the GPU for 2D problems with non-conservative terms enabled.
-"""
+# Compute mortar fluxes on the GPU for 2D problems with non-conservative terms enabled.
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::True,
                            equations, dg::DG, cache)
     surface_flux, nonconservative_flux = dg.surface_integral.surface_flux
@@ -803,11 +707,7 @@ function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservati
     return nothing
 end
 
-"""
-    cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
-
-Accumulate surface contributions into the DG scheme on the GPU for 2D problems.
-"""
+# Accumulate surface contributions into the DG scheme on the GPU for 2D problems.
 function cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
     factor_arr = CuArray([
                              dg.basis.boundary_interpolation[1, 1],
@@ -825,11 +725,7 @@ function cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
     return nothing
 end
 
-"""
-    cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
-
-Apply the inverse Jacobian transformation on the GPU for 2D problems.
-"""
+# Apply the inverse Jacobian transformation on the GPU for 2D problems.
 function cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
     inverse_jacobian = cache.elements.inverse_jacobian
 
@@ -841,20 +737,12 @@ function cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
     return nothing
 end
 
-"""
-    cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{2}, cache)
-
-Dummy function; no operation is required when no source terms are present.
-"""
+# No operation when no source terms are present.
 function cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{2}, cache)
     return nothing
 end
 
-"""
-    cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, cache)
-
-Evaluate and add source terms on the GPU for 2D problems at the current time and node coordinates.
-"""
+# Evaluate and add source terms on the GPU for 2D problems at the current time and node coordinates.
 function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, cache)
     node_coordinates = cache.elements.node_coordinates
 
@@ -866,16 +754,9 @@ function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, 
     return nothing
 end
 
-# Put everything together into a single function.
-# See also `rhs!` function in Trixi.jl
-"""
-    rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations, boundary_conditions,
-             source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
-
-Assemble the semidiscrete right-hand side on the GPU for 2D problems by invoking, in order,
-the DG volume term, interface, boundary and mortar fluxes, surface accumulation, Jacobian 
-transformation, and source terms.
-"""
+# Assemble the semidiscrete right-hand side on the GPU for 2D problems by invoking the 
+# DG volume term, interface, boundary and mortar fluxes, surface accumulation, Jacobian transformation, 
+# and source terms.
 function rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations, boundary_conditions,
                   source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 

--- a/src/solvers/dg_2d.jl
+++ b/src/solvers/dg_2d.jl
@@ -13,7 +13,14 @@ include("dg_2d_kernel.jl")
 # method. But note that there are other factors such as max register number per block and we will
 # enhance the checking mechanism in the future.
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, equations,
+                          volume_integral::VolumeIntegralWeakForm, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 2D problems using the classical weak form 
+volume operator ([`VolumeIntegralWeakForm`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralWeakForm)).
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, equations,
                                volume_integral::VolumeIntegralWeakForm, dg::DG,
                                cache_gpu, cache_cpu)
@@ -50,7 +57,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms, 
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
+                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 2D problems using the flux differencing volume operator 
+([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
+with non-conservative terms disabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
                                cache_gpu, cache_cpu)
@@ -92,7 +107,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
+                          volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 2D problems using the flux differencing volume operator 
+([`VolumeIntegralFluxDifferencing`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralFluxDifferencing))
+with non-conservative terms enabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
                                cache_gpu, cache_cpu)
@@ -151,7 +174,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
+                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 2D problems using the hybrid DG–FV shock capturing operator
+([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
+with non-conservative terms disabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -224,7 +255,15 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+"""
+    cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
+                          volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
+                          cache_gpu, cache_cpu)
+
+Compute the DG volume term on the GPU for 2D problems using the hybrid DG–FV shock capturing operator
+([`VolumeIntegralShockCapturingHG`](https://trixi-framework.github.io/TrixiDocumentation/stable/reference-trixi/#Trixi.VolumeIntegralShockCapturingHG))
+with non-conservative terms enabled.
+"""
 function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -312,7 +351,11 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{2}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for prolonging solution to interfaces
+"""
+    cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
+
+Prolong the solution from element interiors to inter-element interfaces on the GPU for 2D problems.
+"""
 function cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
     neighbor_ids = cache.interfaces.neighbor_ids
     orientations = cache.interfaces.orientations
@@ -330,7 +373,12 @@ function cuda_prolong2interfaces!(u, mesh::TreeMesh{2}, equations, cache)
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+"""
+    cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, equations, dg::DG,
+                         cache)
+
+Compute interface fluxes on the GPU for 2D problems with non-conservative terms disabled.
+"""
 function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -364,7 +412,12 @@ function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::False, e
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+"""
+    cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, equations, dg::DG,
+                         cache)
+
+Compute interface fluxes on the GPU for 2D problems with non-conservative terms enabled.
+"""
 function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -410,13 +463,23 @@ function cuda_interface_flux!(mesh::TreeMesh{2}, nonconservative_terms::True, eq
     return nothing
 end
 
-# Dummy function for asserting boundaries
+"""
+    cuda_prolong2boundaries!(u, mesh::TreeMesh{2},
+                             boundary_condition::BoundaryConditionPeriodic, equations, cache)
+
+Dummy function; no operation is required for periodic boundary conditions.
+"""
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{2},
                                   boundary_condition::BoundaryConditionPeriodic, equations, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for prolonging solution to boundaries
+"""
+    cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::NamedTuple, equations,
+                             cache)
+
+Prolong the solution from element interiors to boundaries on the GPU for 2D problems.
+"""
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::NamedTuple, equations,
                                   cache)
     neighbor_ids = cache.boundaries.neighbor_ids
@@ -438,13 +501,23 @@ function cuda_prolong2boundaries!(u, mesh::TreeMesh{2}, boundary_conditions::Nam
     return nothing
 end
 
-# Dummy function for asserting boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_condition::BoundaryConditionPeriodic,
+                        nonconservative_terms, equations, dg::DG, cache)
+
+Dummy function; no operation is required for periodic boundary conditions.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_condition::BoundaryConditionPeriodic,
                              nonconservative_terms, equations, dg::DG, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for calculating boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
+                        nonconservative_terms::False, equations, dg::DG, cache)
+
+Compute boundary fluxes on the GPU for 2D problems with non-conservative terms disabled.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
                              nonconservative_terms::False, equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -488,7 +561,12 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTup
     return nothing
 end
 
-# Pack kernels for calculating boundary fluxes
+"""
+    cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
+                        nonconservative_terms::True, equations, dg::DG, cache)
+
+Compute boundary fluxes on the GPU for 2D problems with non-conservative terms enabled.
+"""
 function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTuple,
                              nonconservative_terms::True, equations, dg::DG, cache)
     # Contain both conservative and nonconservative fluxes
@@ -535,12 +613,20 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{2}, boundary_conditions::NamedTup
     return nothing
 end
 
-# Dummy function for asserting mortars
+"""
+    cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::False, dg::DG, cache)
+
+No operation. This specialization is used when the semidiscretization does not allocate mortar data.
+"""
 function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::False, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-# Pack kernels for prolonging solution to mortars
+"""
+    cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG, cache)
+
+Prolong the solution from element faces to mortar interfaces on the GPU for 2D problems。
+"""
 function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG, cache)
     neighbor_ids = cache.mortars.neighbor_ids
     large_sides = cache.mortars.large_sides
@@ -580,13 +666,23 @@ function cuda_prolong2mortars!(u, mesh::TreeMesh{2}, cache_mortars::True, dg::DG
     return nothing
 end
 
-# Dummy function for asserting mortar fluxes
+"""
+    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::False, nonconservative_terms,
+                      equations, dg::DG, cache)
+
+No operation. This specialization is used when mortar data are not present.
+"""
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::False, nonconservative_terms,
                            equations, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-# Pack kernels for calculating mortar fluxes
+"""
+    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::False,
+                      equations, dg::DG, cache)
+
+Compute mortar fluxes on the GPU for 2D problems with non-conservative terms disabled.
+"""
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::False,
                            equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -643,7 +739,12 @@ function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservati
     return nothing
 end
 
-# Pack kernels for calculating mortar fluxes
+"""
+    cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::True,
+                      equations, dg::DG, cache)
+
+Compute mortar fluxes on the GPU for 2D problems with non-conservative terms enabled.
+"""
 function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservative_terms::True,
                            equations, dg::DG, cache)
     surface_flux, nonconservative_flux = dg.surface_integral.surface_flux
@@ -702,7 +803,11 @@ function cuda_mortar_flux!(mesh::TreeMesh{2}, cache_mortars::True, nonconservati
     return nothing
 end
 
-# Pack kernels for calculating surface integrals
+"""
+    cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
+
+Accumulate surface contributions into the DG scheme on the GPU for 2D problems.
+"""
 function cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
     factor_arr = CuArray([
                              dg.basis.boundary_interpolation[1, 1],
@@ -720,7 +825,11 @@ function cuda_surface_integral!(du, mesh::TreeMesh{2}, equations, dg::DG, cache)
     return nothing
 end
 
-# Pack kernels for applying Jacobian to reference element
+"""
+    cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
+
+Apply the inverse Jacobian transformation on the GPU for 2D problems.
+"""
 function cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
     inverse_jacobian = cache.elements.inverse_jacobian
 
@@ -732,12 +841,20 @@ function cuda_jacobian!(du, mesh::TreeMesh{2}, equations, cache)
     return nothing
 end
 
-# Dummy function returning nothing              
+"""
+    cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{2}, cache)
+
+Dummy function; no operation is required when no source terms are present.
+"""
 function cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{2}, cache)
     return nothing
 end
 
-# Pack kernels for calculating source terms 
+"""
+    cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, cache)
+
+Evaluate and add source terms on the GPU for 2D problems at the current time and node coordinates.
+"""
 function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, cache)
     node_coordinates = cache.elements.node_coordinates
 
@@ -750,8 +867,15 @@ function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{2}, 
 end
 
 # Put everything together into a single function.
-
 # See also `rhs!` function in Trixi.jl
+"""
+    rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations, boundary_conditions,
+             source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
+
+Assemble the semidiscrete right-hand side on the GPU for 2D problems by invoking, in order,
+the DG volume term, interface, boundary and mortar fluxes, surface accumulation, Jacobian 
+transformation, and source terms.
+"""
 function rhs_gpu!(du, u, t, mesh::TreeMesh{2}, equations, boundary_conditions,
                   source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -13,7 +13,8 @@ include("dg_3d_kernel.jl")
 # method. But note that there are other factors such as max register number per block and we will
 # enhance the checking mechanism in the future.
 
-# Pack kernels for calculating volume integrals
+# Compute the DG volume term on the GPU for 3D problems using the classical 
+# weak form volume operator.
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, equations,
                                volume_integral::VolumeIntegralWeakForm, dg::DG,
                                cache_gpu, cache_cpu)
@@ -51,7 +52,8 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, 
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+# Compute the DG volume term on the GPU for 3D problems using the flux differencing 
+# volume operator with non-conservative terms disabled.
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
                                cache_gpu, cache_cpu)
@@ -99,7 +101,8 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+# Compute the DG volume term on the GPU for 3D problems using the flux differencing 
+# volume operator with non-conservative terms enabled.
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
                                cache_gpu, cache_cpu)
@@ -167,7 +170,8 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+# Compute the DG volume term on the GPU for 3D problems using the hybrid DG 
+# finite volume shock capturing operator with non-conservative terms disabled.
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -250,7 +254,8 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels for calculating volume integrals
+# Compute the DG volume term on the GPU for 3D problems using the hybrid DG finite volume 
+# shock capturing operator with non-conservative terms enabled.
 function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True, equations,
                                volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
                                cache_gpu, cache_cpu)
@@ -352,7 +357,7 @@ function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::
     return nothing
 end
 
-# Pack kernels to prolonging solution to interfaces
+# Prolong the solution from element interiors to interelement interfaces on the GPU for 3D problems.
 function cuda_prolong2interfaces!(u, mesh::TreeMesh{3}, equations, cache)
     neighbor_ids = cache.interfaces.neighbor_ids
     orientations = cache.interfaces.orientations
@@ -371,7 +376,7 @@ function cuda_prolong2interfaces!(u, mesh::TreeMesh{3}, equations, cache)
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+# Compute interface fluxes on the GPU for 3D problems with non-conservative terms disabled.
 function cuda_interface_flux!(mesh::TreeMesh{3}, nonconservative_terms::False, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -406,7 +411,7 @@ function cuda_interface_flux!(mesh::TreeMesh{3}, nonconservative_terms::False, e
     return nothing
 end
 
-# Pack kernels for calculating interface fluxes
+# Compute interface fluxes on the GPU for 3D problems with non-conservative terms enabled.
 function cuda_interface_flux!(mesh::TreeMesh{3}, nonconservative_terms::True, equations, dg::DG,
                               cache)
     RealT = eltype(cache.elements)
@@ -454,13 +459,13 @@ function cuda_interface_flux!(mesh::TreeMesh{3}, nonconservative_terms::True, eq
     return nothing
 end
 
-# Dummy function for asserting boundaries
+# No operation for periodic boundary conditions.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{3},
                                   boundary_condition::BoundaryConditionPeriodic, equations, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for prolonging solution to boundaries
+# Prolong the solution from element interiors to boundaries on the GPU for 3D problems.
 function cuda_prolong2boundaries!(u, mesh::TreeMesh{3}, boundary_conditions::NamedTuple, equations,
                                   cache)
     neighbor_ids = cache.boundaries.neighbor_ids
@@ -483,13 +488,13 @@ function cuda_prolong2boundaries!(u, mesh::TreeMesh{3}, boundary_conditions::Nam
     return nothing
 end
 
-# Dummy function for asserting boundary fluxes
+# No operation for periodic boundary conditions.
 function cuda_boundary_flux!(t, mesh::TreeMesh{3}, boundary_condition::BoundaryConditionPeriodic,
                              nonconservative_terms, equations, dg::DG, cache)
     @assert iszero(length(cache.boundaries.orientations))
 end
 
-# Pack kernels for calculating boundary fluxes
+# Compute boundary fluxes on the GPU for 3D problems with non-conservative terms enabled.
 function cuda_boundary_flux!(t, mesh::TreeMesh{3}, boundary_conditions::NamedTuple,
                              nonconservative_terms, equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -533,12 +538,12 @@ function cuda_boundary_flux!(t, mesh::TreeMesh{3}, boundary_conditions::NamedTup
     return nothing
 end
 
-# Dummy function for asserting mortars 
+# No operation when mortar data are not allocated.
 function cuda_prolong2mortars!(u, mesh::TreeMesh{3}, cache_mortars::False, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-# Pack kernels for prolonging solution to mortars
+# Prolong the solution from element faces to mortar interfaces on the GPU for 3D problems.
 function cuda_prolong2mortars!(u, mesh::TreeMesh{3}, cache_mortars::True, dg::DG, cache)
     neighbor_ids = cache.mortars.neighbor_ids
     large_sides = cache.mortars.large_sides
@@ -612,13 +617,13 @@ function cuda_prolong2mortars!(u, mesh::TreeMesh{3}, cache_mortars::True, dg::DG
     return nothing
 end
 
-# Dummy function for asserting mortar fluxes
+# No operation when mortar data are not present.
 function cuda_mortar_flux!(mesh::TreeMesh{3}, cache_mortars::False, nonconservative_terms,
                            equations, dg::DG, cache)
     @assert iszero(length(cache.mortars.orientations))
 end
 
-# Pack kernels for calculating mortar fluxes
+# Compute mortar fluxes on the GPU for 3D problems with non-conservative terms disabled.
 function cuda_mortar_flux!(mesh::TreeMesh{3}, cache_mortars::True, nonconservative_terms::False,
                            equations, dg::DG, cache)
     surface_flux = dg.surface_integral.surface_flux
@@ -727,7 +732,7 @@ function cuda_mortar_flux!(mesh::TreeMesh{3}, cache_mortars::True, nonconservati
     return nothing
 end
 
-# Pack kernels for calculating mortar fluxes
+# Compute mortar fluxes on the GPU for 3D problems with non-conservative terms enabled.
 function cuda_mortar_flux!(mesh::TreeMesh{3}, cache_mortars::True, nonconservative_terms::True,
                            equations, dg::DG, cache)
     surface_flux, nonconservative_flux = dg.surface_integral.surface_flux
@@ -837,7 +842,7 @@ function cuda_mortar_flux!(mesh::TreeMesh{3}, cache_mortars::True, nonconservati
     return nothing
 end
 
-# Pack kernels for calculating surface integrals
+# Accumulate surface contributions into the DG scheme on the GPU for 3D problems.
 function cuda_surface_integral!(du, mesh::TreeMesh{3}, equations, dg::DG, cache)
     factor_arr = CuArray([
                              dg.basis.boundary_interpolation[1, 1],
@@ -855,7 +860,7 @@ function cuda_surface_integral!(du, mesh::TreeMesh{3}, equations, dg::DG, cache)
     return nothing
 end
 
-# Pack kernels for applying Jacobian to reference element
+# Apply the inverse Jacobian transformation on the GPU for 3D problems.
 function cuda_jacobian!(du, mesh::TreeMesh{3}, equations, cache)
     inverse_jacobian = cache.elements.inverse_jacobian
 
@@ -867,12 +872,12 @@ function cuda_jacobian!(du, mesh::TreeMesh{3}, equations, cache)
     return nothing
 end
 
-# Dummy function returning nothing            
+# No operation when no source terms are present.
 function cuda_sources!(du, u, t, source_terms::Nothing, equations::AbstractEquations{3}, cache)
     return nothing
 end
 
-# Pack kernels for calculating source terms 
+# Evaluate and add source terms on the GPU for 3D problems at the current time and  node coordinates.
 function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{3}, cache)
     node_coordinates = cache.elements.node_coordinates
 
@@ -884,9 +889,9 @@ function cuda_sources!(du, u, t, source_terms, equations::AbstractEquations{3}, 
     return nothing
 end
 
-# Put everything together into a single function.
-
-# See also `rhs!` function in Trixi.jl
+# Assemble the semidiscrete right-hand side on the GPU for 3D problems by invoking volume, 
+# interface, boundary and mortar fluxes, surface accumulation, Jacobian transformation, and 
+# source terms.
 function rhs_gpu!(du, u, t, mesh::TreeMesh{3}, equations, boundary_conditions,
                   source_terms::Source, dg::DG, cache_gpu, cache_cpu) where {Source}
     # reset_du!(du) 

--- a/src/solvers/dg_3d.jl
+++ b/src/solvers/dg_3d.jl
@@ -15,9 +15,9 @@ include("dg_3d_kernel.jl")
 
 # Compute the DG volume term on the GPU for 3D problems using the classical 
 # weak form volume operator.
-function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms, equations,
-                               volume_integral::VolumeIntegralWeakForm, dg::DG,
-                               cache_gpu, cache_cpu)
+function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms,
+                               equations, volume_integral::VolumeIntegralWeakForm,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     derivative_dhat = dg.basis.derivative_dhat
@@ -54,9 +54,9 @@ end
 
 # Compute the DG volume term on the GPU for 3D problems using the flux differencing 
 # volume operator with non-conservative terms disabled.
-function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux = volume_integral.volume_flux
@@ -103,9 +103,9 @@ end
 
 # Compute the DG volume term on the GPU for 3D problems using the flux differencing 
 # volume operator with non-conservative terms enabled.
-function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralFluxDifferencing, dg::DG,
-                               cache_gpu, cache_cpu)
+function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralFluxDifferencing,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     symmetric_flux, nonconservative_flux = dg.volume_integral.volume_flux
@@ -172,9 +172,9 @@ end
 
 # Compute the DG volume term on the GPU for 3D problems using the hybrid DG 
 # finite volume shock capturing operator with non-conservative terms disabled.
-function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::False,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, volume_flux_fv = dg.volume_integral.volume_flux_dg,
@@ -256,9 +256,9 @@ end
 
 # Compute the DG volume term on the GPU for 3D problems using the hybrid DG finite volume 
 # shock capturing operator with non-conservative terms enabled.
-function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True, equations,
-                               volume_integral::VolumeIntegralShockCapturingHG, dg::DG,
-                               cache_gpu, cache_cpu)
+function cuda_volume_integral!(du, u, mesh::TreeMesh{3}, nonconservative_terms::True,
+                               equations, volume_integral::VolumeIntegralShockCapturingHG,
+                               dg::DG, cache_gpu, cache_cpu)
     RealT = eltype(du)
 
     volume_flux_dg, noncons_flux_dg = dg.volume_integral.volume_flux_dg


### PR DESCRIPTION
We add the documentations for all the GPU kernels in the semidiscretization. Note that this serves as a temporary docs as its name and argument may changes in the future for optimization.

- [x] 1D kernels
- [x] 2D kernels
- [x] 3D kernels